### PR TITLE
Add CI clang-format check.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -117,7 +117,7 @@ PenaltyBreakTemplateDeclaration: 10
 PenaltyExcessCharacter: 1000000
 PenaltyIndentedWhitespace: 0
 PenaltyReturnTypeOnItsOwnLine: 1000
-PointerAlignment: Right
+PointerAlignment: Left
 PPIndentWidth:   -1
 QualifierAlignment: Leave
 ReferenceAlignment: Pointer

--- a/.github/workflows/clang-format.yaml
+++ b/.github/workflows/clang-format.yaml
@@ -1,0 +1,16 @@
+name: clang-format Check
+
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  formatting-check:
+    name: clang-format Formatting Check
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Run clang-format style check for C++ files.
+      uses: jidicula/clang-format-action@v4.11.0
+      with:
+        clang-format-version: '17'
+        check-path: 'src'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,6 +6,6 @@ repos:
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
 -   repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: ''  # Use the sha / tag you want to point at
+    rev: 'v17.0.6'  # Use the sha / tag you want to point at
     hooks:
     -   id: clang-format

--- a/README.md
+++ b/README.md
@@ -9,6 +9,13 @@ TBD...
 - Docker
 - Google Test
 - C++20
+- clang-format (recommended minimum ver. 17)
+
+### Format code before committing
+
+```bash
+find . -name '*.cpp' -or -name '*.h' | xargs clang-format --verbose -style=file -i
+```
 
 ### Build
 

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -1,7 +1,7 @@
-#include <QApplication>
 #include "mainwindow.h"
+#include <QApplication>
 
-int main(int argc, char *argv[])
+int main(int argc, char* argv[])
 {
     QApplication a(argc, argv);
     MainWindow w;

--- a/src/app/mainwindow.cpp
+++ b/src/app/mainwindow.cpp
@@ -1,7 +1,7 @@
 #include "mainwindow.h"
 #include "ui_mainwindow.h"
 
-MainWindow::MainWindow(QWidget *parent)
+MainWindow::MainWindow(QWidget* parent)
     : QMainWindow(parent), ui(std::make_unique<Ui::MainWindow>()) // Use std::make_unique for
                                                                   // initialization
 {

--- a/src/app/mainwindow.h
+++ b/src/app/mainwindow.h
@@ -16,7 +16,7 @@ class MainWindow : public QMainWindow
     Q_OBJECT
 
   public:
-    MainWindow(QWidget *parent = nullptr);
+    MainWindow(QWidget* parent = nullptr);
     ~MainWindow();
 
   private:

--- a/src/app/person/person.hpp
+++ b/src/app/person/person.hpp
@@ -8,7 +8,7 @@ class Person
     std::string first_name_;
     std::string last_name_;
     std::string pesel_;
-    
+
   public:
     explicit Person(std::string first_name, std::string last_name, std::string pesel);
     virtual ~Person();

--- a/src/app/receptionist/shift.cpp
+++ b/src/app/receptionist/shift.cpp
@@ -1,6 +1,6 @@
 #include "shift.hpp"
 
-std::string toString(const Shift &shift)
+std::string toString(const Shift& shift)
 {
     std::string shift_text{};
 

--- a/src/app/visit/visit.cpp
+++ b/src/app/visit/visit.cpp
@@ -1,7 +1,7 @@
 #include "visit.hpp"
 #include "../doctor/doctor.hpp"
 
-std::set<Visit *> Visit::visit_extent_;
+std::set<Visit*> Visit::visit_extent_;
 
 Visit::Visit()
 {
@@ -20,12 +20,12 @@ std::shared_ptr<Visit> Visit::createVisit(std::shared_ptr<Doctor> doctor)
     return visit;
 }
 
-std::set<Visit *> Visit::getExtent()
+std::set<Visit*> Visit::getExtent()
 {
     return visit_extent_;
 }
 
-void Visit::removeFromExtent(Visit *visit)
+void Visit::removeFromExtent(Visit* visit)
 {
     auto it = visit_extent_.find(visit);
     if (it != visit_extent_.end())


### PR DESCRIPTION
Rationale: if somobody did not install pre-commit or uses it improperly, this might be best place to protectd against accidental code reformatting