### PR TITLE
Treatment enum

### DIFF
--- a/src/app/visit/CMakeLists.txt
+++ b/src/app/visit/CMakeLists.txt
@@ -2,4 +2,5 @@ add_library(visit-lib visit.cpp
                       treatment.cpp)
 
 target_compile_options(visit-lib PRIVATE -Werror -Wall -Wextra -pedantic)
+target_link_libraries(visit-lib PRIVATE doctor-lib)
 target_include_directories(visit-lib PUBLIC .)

--- a/src/app/visit/CMakeLists.txt
+++ b/src/app/visit/CMakeLists.txt
@@ -1,4 +1,5 @@
-add_library(visit-lib visit.cpp)
+add_library(visit-lib visit.cpp
+                      treatment.cpp)
 
 target_compile_options(visit-lib PRIVATE -Werror -Wall -Wextra -pedantic)
 target_include_directories(visit-lib PUBLIC .)

--- a/src/app/visit/treatment.cpp
+++ b/src/app/visit/treatment.cpp
@@ -1,0 +1,29 @@
+#include "treatment.hpp"
+
+#include <map>
+#include <stdexcept>
+
+namespace
+{
+const std::map<Treatment, std::string> DentalTreatments = {
+    {Treatment::TeethCleaning, "Teeth Cleaning"},   {Treatment::RootCanal, "Root Canal"},
+    {Treatment::DentalFilling, "Dental Filling"},   {Treatment::ToothExtraction, "Tooth Extraction"},
+    {Treatment::TeethWhitening, "Teeth Whitening"}, {Treatment::DentalImplants, "Dental Implants"},
+    {Treatment::Orthodontics, "Orthodontics"},      {Treatment::Periodontics, "Periodontics"},
+    {Treatment::DentalVeneers, "Dental Veneers"},   {Treatment::DentalCrowns, "Dental Crowns"},
+    {Treatment::DentalBridges, "Dental Bridges"},   {Treatment::Dentures, "Dentures"},
+    {Treatment::GumSurgery, "Gum Surgery"},         {Treatment::DentalSealants, "Dental Sealants"},
+    {Treatment::MouthGuards, "Mouth Guards"},       {Treatment::SleepApneaTreatment, "Sleep Apnea Treatment"}};
+} // namespace
+
+std::string toString(Treatment dentalTreatment)
+{
+    try
+    {
+        return DentalTreatments.at(dentalTreatment);
+    }
+    catch (const std::out_of_range& atException)
+    {
+        return "Unknown treatment enum value!";
+    }
+}

--- a/src/app/visit/treatment.cpp
+++ b/src/app/visit/treatment.cpp
@@ -6,24 +6,20 @@
 namespace
 {
 const std::map<Treatment, std::string> DentalTreatments = {
-    {Treatment::TeethCleaning, "Teeth Cleaning"},   {Treatment::RootCanal, "Root Canal"},
-    {Treatment::DentalFilling, "Dental Filling"},   {Treatment::ToothExtraction, "Tooth Extraction"},
-    {Treatment::TeethWhitening, "Teeth Whitening"}, {Treatment::DentalImplants, "Dental Implants"},
-    {Treatment::Orthodontics, "Orthodontics"},      {Treatment::Periodontics, "Periodontics"},
-    {Treatment::DentalVeneers, "Dental Veneers"},   {Treatment::DentalCrowns, "Dental Crowns"},
-    {Treatment::DentalBridges, "Dental Bridges"},   {Treatment::Dentures, "Dentures"},
-    {Treatment::GumSurgery, "Gum Surgery"},         {Treatment::DentalSealants, "Dental Sealants"},
-    {Treatment::MouthGuards, "Mouth Guards"},       {Treatment::SleepApneaTreatment, "Sleep Apnea Treatment"}};
+    {Treatment::TeethCleaning, "teeth cleaning"},   {Treatment::RootCanal, "root canal"},
+    {Treatment::DentalFilling, "dental filling"},   {Treatment::ToothExtraction, "tooth extraction"},
+    {Treatment::TeethWhitening, "teeth whitening"}, {Treatment::DentalImplants, "dental implants"},
+    {Treatment::Orthodontics, "orthodontics"},      {Treatment::Periodontics, "periodontics"},
+    {Treatment::DentalVeneers, "dental veneers"},   {Treatment::DentalCrowns, "dental crowns"},
+    {Treatment::DentalBridges, "dental bridges"},   {Treatment::Dentures, "dentures"},
+    {Treatment::GumSurgery, "gum surgery"},         {Treatment::DentalSealants, "dental sealants"},
+    {Treatment::MouthGuards, "mouth guards"},       {Treatment::SleepApneaTreatment, "sleep apnea treatment"},
+    {Treatment::OTHER, "other treatment type"}};
 } // namespace
 
-std::string toString(Treatment dentalTreatment)
+std::string toString(Treatment dental_treatment)
 {
-    try
-    {
-        return DentalTreatments.at(dentalTreatment);
-    }
-    catch (const std::out_of_range& atException)
-    {
-        return "Unknown treatment enum value!";
-    }
+    auto searched_pair = DentalTreatments.find(dental_treatment);
+
+    return searched_pair != DentalTreatments.end() ? searched_pair->second : "other treatment type";
 }

--- a/src/app/visit/treatment.hpp
+++ b/src/app/visit/treatment.hpp
@@ -1,25 +1,27 @@
 #pragma once
 
+#include <cstdint>
 #include <string>
 
-enum class Treatment : unsigned
+enum class Treatment : uint32_t
 {
-    TeethCleaning,
-    RootCanal,
-    DentalFilling,
-    ToothExtraction,
-    TeethWhitening,
-    DentalImplants,
-    Orthodontics,
-    Periodontics,
-    DentalVeneers,
-    DentalCrowns,
-    DentalBridges,
-    Dentures,
-    GumSurgery,
-    DentalSealants,
-    MouthGuards,
-    SleepApneaTreatment
+    TeethCleaning = 0,
+    RootCanal = 1,
+    DentalFilling = 2,
+    ToothExtraction = 3,
+    TeethWhitening = 4,
+    DentalImplants = 5,
+    Orthodontics = 6,
+    Periodontics = 7,
+    DentalVeneers = 8,
+    DentalCrowns = 9,
+    DentalBridges = 10,
+    Dentures = 11,
+    GumSurgery = 12,
+    DentalSealants = 13,
+    MouthGuards = 14,
+    SleepApneaTreatment = 15,
+    OTHER = 16
 };
 
-std::string toString(Treatment dentalTreatment);
+std::string toString(Treatment dental_treatment);

--- a/src/app/visit/treatment.hpp
+++ b/src/app/visit/treatment.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <string>
+
+enum class Treatment : unsigned
+{
+    TeethCleaning,
+    RootCanal,
+    DentalFilling,
+    ToothExtraction,
+    TeethWhitening,
+    DentalImplants,
+    Orthodontics,
+    Periodontics,
+    DentalVeneers,
+    DentalCrowns,
+    DentalBridges,
+    Dentures,
+    GumSurgery,
+    DentalSealants,
+    MouthGuards,
+    SleepApneaTreatment
+};
+
+std::string toString(Treatment dentalTreatment);

--- a/src/app/visit/visit.cpp
+++ b/src/app/visit/visit.cpp
@@ -13,9 +13,10 @@ Visit::~Visit()
     removeFromExtent(this);
 }
 
-std::shared_ptr<Visit> Visit::createVisit(std::shared_ptr<Doctor> doctor, std::vector<Treatment> predictedTreatments)
+std::shared_ptr<Visit> Visit::createVisit(const std::shared_ptr<Doctor>& doctor,
+                                          const std::vector<Treatment>& predicted_treatments)
 {
-    auto visit = std::shared_ptr<Visit>(new Visit(std::move(predictedTreatments)));
+    auto visit = std::shared_ptr<Visit>(new Visit(predicted_treatments));
     doctor->addVisitAssociation(visit);
 
     return visit;
@@ -64,7 +65,7 @@ std::string Visit::getVisitInformation() const
     return visit_information_;
 }
 
-void Visit::updateTreatments(std::vector<Treatment> newTreatments)
+void Visit::updateTreatments(const std::vector<Treatment>& new_treatments)
 {
-    treatments_ = std::move(newTreatments);
+    treatments_ = new_treatments;
 }

--- a/src/app/visit/visit.cpp
+++ b/src/app/visit/visit.cpp
@@ -1,9 +1,9 @@
 #include "visit.hpp"
-#include "../doctor/doctor.hpp"
+#include "doctor.hpp"
 
 std::set<Visit*> Visit::visit_extent_;
 
-Visit::Visit()
+Visit::Visit(std::vector<Treatment> predictedTreatments) : treatments_(std::move(predictedTreatments))
 {
     visit_extent_.insert(this);
 }
@@ -13,10 +13,11 @@ Visit::~Visit()
     removeFromExtent(this);
 }
 
-std::shared_ptr<Visit> Visit::createVisit(std::shared_ptr<Doctor> doctor)
+std::shared_ptr<Visit> Visit::createVisit(std::shared_ptr<Doctor> doctor, std::vector<Treatment> predictedTreatments)
 {
-    auto visit = std::shared_ptr<Visit>(new Visit());
+    auto visit = std::shared_ptr<Visit>(new Visit(std::move(predictedTreatments)));
     doctor->addVisitAssociation(visit);
+
     return visit;
 }
 
@@ -48,6 +49,11 @@ std::shared_ptr<Doctor> Visit::getDoctorAssociation() const
     return doctor_association_;
 }
 
+std::vector<Treatment> Visit::getTreatments() const
+{
+    return treatments_;
+}
+
 void Visit::setVisitInformation(const std::string& visit_information)
 {
     visit_information_ = visit_information;
@@ -56,4 +62,9 @@ void Visit::setVisitInformation(const std::string& visit_information)
 std::string Visit::getVisitInformation() const
 {
     return visit_information_;
+}
+
+void Visit::updateTreatments(std::vector<Treatment> newTreatments)
+{
+    treatments_ = std::move(newTreatments);
 }

--- a/src/app/visit/visit.hpp
+++ b/src/app/visit/visit.hpp
@@ -1,25 +1,33 @@
 #pragma once
 
+#include "treatment.hpp"
+
 #include <memory>
 #include <set>
 #include <string>
+#include <vector>
 
 class Doctor;
 
 class Visit : public std::enable_shared_from_this<Visit>
 {
-    Visit();
+    Visit(std::vector<Treatment> predictedTreatments);
+
     static std::set<Visit*> visit_extent_;
     std::shared_ptr<Doctor> doctor_association_;
     std::string visit_information_;
+    std::vector<Treatment> treatments_;
 
   public:
     ~Visit();
-    static std::shared_ptr<Visit> createVisit(std::shared_ptr<Doctor> doctor);
+    static std::shared_ptr<Visit> createVisit(std::shared_ptr<Doctor> doctor,
+                                              std::vector<Treatment> predictedTreatments = {});
     static std::set<Visit*> getExtent();
     static void removeFromExtent(Visit* visit);
     void setDoctorAssociation(const std::shared_ptr<Doctor>& doctor);
     std::shared_ptr<Doctor> getDoctorAssociation() const;
     void setVisitInformation(const std::string& visit_information);
     std::string getVisitInformation() const;
+    std::vector<Treatment> getTreatments() const;
+    void updateTreatments(std::vector<Treatment> newTreatments);
 };

--- a/src/app/visit/visit.hpp
+++ b/src/app/visit/visit.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "treatment.hpp"
-
 #include <memory>
 #include <set>
 #include <string>
@@ -20,8 +19,8 @@ class Visit : public std::enable_shared_from_this<Visit>
 
   public:
     ~Visit();
-    static std::shared_ptr<Visit> createVisit(std::shared_ptr<Doctor> doctor,
-                                              std::vector<Treatment> predictedTreatments = {});
+    static std::shared_ptr<Visit> createVisit(const std::shared_ptr<Doctor>& doctor,
+                                              const std::vector<Treatment>& predicted_treatments = {});
     static std::set<Visit*> getExtent();
     static void removeFromExtent(Visit* visit);
     void setDoctorAssociation(const std::shared_ptr<Doctor>& doctor);
@@ -29,5 +28,5 @@ class Visit : public std::enable_shared_from_this<Visit>
     void setVisitInformation(const std::string& visit_information);
     std::string getVisitInformation() const;
     std::vector<Treatment> getTreatments() const;
-    void updateTreatments(std::vector<Treatment> newTreatments);
+    void updateTreatments(const std::vector<Treatment>& new_treatments);
 };

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -1,6 +1,8 @@
 set(UT_SOURCES ut/receptionist/receptionist_test.cpp
                ut/receptionist/shift_test.cpp
-               ut/visit/visit_test.cpp)
+               ut/visit/treatment_test.cpp
+               ut/visit/visit_test.cpp
+)
 # NOTE: similar set for INTEGRATION_SOURCES to be done when tests apear
 
 include(GoogleTest)

--- a/src/tests/ut/visit/treatment_test.cpp
+++ b/src/tests/ut/visit/treatment_test.cpp
@@ -3,15 +3,16 @@
 namespace
 {
 
-const std::map<Treatment, std::string> expectedDentalTreatments = {
-    {Treatment::TeethCleaning, "Teeth Cleaning"},   {Treatment::RootCanal, "Root Canal"},
-    {Treatment::DentalFilling, "Dental Filling"},   {Treatment::ToothExtraction, "Tooth Extraction"},
-    {Treatment::TeethWhitening, "Teeth Whitening"}, {Treatment::DentalImplants, "Dental Implants"},
-    {Treatment::Orthodontics, "Orthodontics"},      {Treatment::Periodontics, "Periodontics"},
-    {Treatment::DentalVeneers, "Dental Veneers"},   {Treatment::DentalCrowns, "Dental Crowns"},
-    {Treatment::DentalBridges, "Dental Bridges"},   {Treatment::Dentures, "Dentures"},
-    {Treatment::GumSurgery, "Gum Surgery"},         {Treatment::DentalSealants, "Dental Sealants"},
-    {Treatment::MouthGuards, "Mouth Guards"},       {Treatment::SleepApneaTreatment, "Sleep Apnea Treatment"}};
+const std::map<Treatment, std::string> TestParams = {
+    {Treatment::TeethCleaning, "teeth cleaning"},   {Treatment::RootCanal, "root canal"},
+    {Treatment::DentalFilling, "dental filling"},   {Treatment::ToothExtraction, "tooth extraction"},
+    {Treatment::TeethWhitening, "teeth whitening"}, {Treatment::DentalImplants, "dental implants"},
+    {Treatment::Orthodontics, "orthodontics"},      {Treatment::Periodontics, "periodontics"},
+    {Treatment::DentalVeneers, "dental veneers"},   {Treatment::DentalCrowns, "dental crowns"},
+    {Treatment::DentalBridges, "dental bridges"},   {Treatment::Dentures, "dentures"},
+    {Treatment::GumSurgery, "gum surgery"},         {Treatment::DentalSealants, "dental sealants"},
+    {Treatment::MouthGuards, "mouth guards"},       {Treatment::SleepApneaTreatment, "sleep apnea treatment"},
+    {Treatment::OTHER, "other treatment type"}};
 
 TEST_P(TreatmentParameterizedFixture, GivenTreatmentEnumToStringShouldProvideCorrectStringRepresentation)
 {
@@ -22,5 +23,5 @@ TEST_P(TreatmentParameterizedFixture, GivenTreatmentEnumToStringShouldProvideCor
 }
 
 INSTANTIATE_TEST_SUITE_P(TreatmentConversionToStringTest, TreatmentParameterizedFixture,
-                         ::testing::ValuesIn(expectedDentalTreatments));
+                         ::testing::ValuesIn(TestParams));
 } // namespace

--- a/src/tests/ut/visit/treatment_test.cpp
+++ b/src/tests/ut/visit/treatment_test.cpp
@@ -1,0 +1,26 @@
+#include "treatment_test.hpp"
+
+namespace
+{
+
+const std::map<Treatment, std::string> expectedDentalTreatments = {
+    {Treatment::TeethCleaning, "Teeth Cleaning"},   {Treatment::RootCanal, "Root Canal"},
+    {Treatment::DentalFilling, "Dental Filling"},   {Treatment::ToothExtraction, "Tooth Extraction"},
+    {Treatment::TeethWhitening, "Teeth Whitening"}, {Treatment::DentalImplants, "Dental Implants"},
+    {Treatment::Orthodontics, "Orthodontics"},      {Treatment::Periodontics, "Periodontics"},
+    {Treatment::DentalVeneers, "Dental Veneers"},   {Treatment::DentalCrowns, "Dental Crowns"},
+    {Treatment::DentalBridges, "Dental Bridges"},   {Treatment::Dentures, "Dentures"},
+    {Treatment::GumSurgery, "Gum Surgery"},         {Treatment::DentalSealants, "Dental Sealants"},
+    {Treatment::MouthGuards, "Mouth Guards"},       {Treatment::SleepApneaTreatment, "Sleep Apnea Treatment"}};
+
+TEST_P(TreatmentParameterizedFixture, GivenTreatmentEnumToStringShouldProvideCorrectStringRepresentation)
+{
+
+    const auto& [enumValue, stringRepresentation] = GetParam();
+
+    EXPECT_EQ(toString(enumValue), stringRepresentation);
+}
+
+INSTANTIATE_TEST_SUITE_P(TreatmentConversionToStringTest, TreatmentParameterizedFixture,
+                         ::testing::ValuesIn(expectedDentalTreatments));
+} // namespace

--- a/src/tests/ut/visit/treatment_test.hpp
+++ b/src/tests/ut/visit/treatment_test.hpp
@@ -4,8 +4,8 @@
 
 #include "treatment.hpp"
 
-using TreatmentWithStringRepresentation = std::pair<const Treatment, std::string>;
+using TestParam = std::pair<const Treatment, std::string>;
 
-struct TreatmentParameterizedFixture : public ::testing::TestWithParam<TreatmentWithStringRepresentation>
+struct TreatmentParameterizedFixture : public ::testing::TestWithParam<TestParam>
 {
 };

--- a/src/tests/ut/visit/treatment_test.hpp
+++ b/src/tests/ut/visit/treatment_test.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "gtest/gtest.h"
+
+#include "treatment.hpp"
+
+using TreatmentWithStringRepresentation = std::pair<const Treatment, std::string>;
+
+struct TreatmentParameterizedFixture : public ::testing::TestWithParam<TreatmentWithStringRepresentation>
+{
+};

--- a/src/tests/ut/visit/visit_test.cpp
+++ b/src/tests/ut/visit/visit_test.cpp
@@ -2,6 +2,8 @@
 
 #include "visit_test.hpp"
 
+#include <algorithm>
+
 namespace
 {
 TEST_F(AssociationTest, ExtentDemo)
@@ -29,20 +31,11 @@ TEST_F(AssociationTest, AssociationDemo3)
 {
     std::string content;
     auto associations = doc2->getVisitAssociations();
-    if (auto it = associations.begin(); it != associations.end())
-    {
-        std::advance(it, 1);
-        if (it != doc2->getVisitAssociations().end())
-        {
-            content = it->get()->getVisitInformation();
-        }
-        else
-        {
-            content = "null";
-        }
-    }
+
     auto expected = "I w klubie sa sami fajni ludzie";
-    EXPECT_EQ(content, expected);
+
+    EXPECT_TRUE(std::ranges::any_of(
+        associations, [&expected](const auto& visitSPtr) { return visitSPtr->getVisitInformation() == expected; }));
 }
 
 } // namespace

--- a/src/tests/ut/visit/visit_test.cpp
+++ b/src/tests/ut/visit/visit_test.cpp
@@ -8,31 +8,31 @@ namespace
 {
 TEST_F(VisitTestsFixture, ExtentDemo)
 {
-    const auto& content = Visit::getExtent().size();
-    const auto& expected = 3;
+    const auto content = Visit::getExtent().size();
+    const auto expected = 3;
     EXPECT_EQ(content, expected);
 }
 
 TEST_F(VisitTestsFixture, AssociationDemo)
 {
-    const auto& content = visit1->getDoctorAssociation()->getLastName();
-    const auto& expected = "Tracz";
+    const auto content = visit1->getDoctorAssociation()->getLastName();
+    const auto expected = "Tracz";
     EXPECT_EQ(content, expected);
 }
 
 TEST_F(VisitTestsFixture, AssociationDemo2)
 {
-    const auto& content = doc2->getVisitAssociations().begin()->get()->getVisitInformation();
-    const auto& expected = "Tworze klub ninja!";
+    const auto content = doc2->getVisitAssociations().begin()->get()->getVisitInformation();
+    const auto expected = "Tworze klub ninja!";
     EXPECT_EQ(content, expected);
 }
 
 TEST_F(VisitTestsFixture, AssociationDemo3)
 {
     std::string content;
-    const auto& associations = doc2->getVisitAssociations();
+    const auto associations = doc2->getVisitAssociations();
 
-    const auto& expected = "I w klubie sa sami fajni ludzie";
+    const auto expected = "I w klubie sa sami fajni ludzie";
 
     bool associationsContainExpectedVisitInformation = std::ranges::any_of(
         associations, [&expected](const auto& visitSPtr) { return visitSPtr->getVisitInformation() == expected; });
@@ -42,9 +42,9 @@ TEST_F(VisitTestsFixture, AssociationDemo3)
 
 TEST_F(VisitTestsFixture, UpdateTreatmentsShouldReplacePreviouslyStoredTreatments)
 {
-    const auto& visitOneTreatmentsBefore = visit1->getTreatments();
-    const auto& visitTwoTreatmentsBefore = visit2->getTreatments();
-    const auto& visitThreeTreatmentsBefore = visit3->getTreatments();
+    const auto visitOneTreatmentsBefore = visit1->getTreatments();
+    const auto visitTwoTreatmentsBefore = visit2->getTreatments();
+    const auto visitThreeTreatmentsBefore = visit3->getTreatments();
     ASSERT_TRUE(visitOneTreatmentsBefore.empty());
     ASSERT_EQ(visitTwoTreatmentsBefore, std::vector{Treatment::TeethWhitening});
     ASSERT_EQ(visitThreeTreatmentsBefore,

--- a/src/tests/ut/visit/visit_test.cpp
+++ b/src/tests/ut/visit/visit_test.cpp
@@ -6,28 +6,28 @@
 
 namespace
 {
-TEST_F(AssociationTest, ExtentDemo)
+TEST_F(VisitTestsFixture, ExtentDemo)
 {
     auto content = Visit::getExtent().size();
     auto expected = 3;
     EXPECT_EQ(content, expected);
 }
 
-TEST_F(AssociationTest, AssociationDemo)
+TEST_F(VisitTestsFixture, AssociationDemo)
 {
     auto content = visit1->getDoctorAssociation()->getLastName();
     auto expected = "Tracz";
     EXPECT_EQ(content, expected);
 }
 
-TEST_F(AssociationTest, AssociationDemo2)
+TEST_F(VisitTestsFixture, AssociationDemo2)
 {
     auto content = doc2->getVisitAssociations().begin()->get()->getVisitInformation();
     auto expected = "Tworze klub ninja!";
     EXPECT_EQ(content, expected);
 }
 
-TEST_F(AssociationTest, AssociationDemo3)
+TEST_F(VisitTestsFixture, AssociationDemo3)
 {
     std::string content;
     auto associations = doc2->getVisitAssociations();
@@ -36,6 +36,29 @@ TEST_F(AssociationTest, AssociationDemo3)
 
     EXPECT_TRUE(std::ranges::any_of(
         associations, [&expected](const auto& visitSPtr) { return visitSPtr->getVisitInformation() == expected; }));
+}
+
+TEST_F(VisitTestsFixture, UpdateTreatmentsShouldReplacePreviouslyStoredTreatments)
+{
+    auto visitOneTreatmentsBefore = visit1->getTreatments();
+    auto visitTwoTreatmentsBefore = visit2->getTreatments();
+    auto visitThreeTreatmentsBefore = visit3->getTreatments();
+    // initial asserts
+    ASSERT_TRUE(visitOneTreatmentsBefore.empty());
+    ASSERT_EQ(visitTwoTreatmentsBefore, std::vector{Treatment::TeethWhitening});
+    ASSERT_EQ(visitThreeTreatmentsBefore,
+              (std::vector{Treatment::TeethCleaning, Treatment::RootCanal, Treatment::ToothExtraction}));
+
+    // update treatments for visit
+    std::vector newTreatmentsForVisit1 = {Treatment::GumSurgery};
+    std::vector newTreatmentsForVisit2 = {Treatment::DentalFilling, Treatment::DentalSealants};
+    visit1->updateTreatments(newTreatmentsForVisit1);
+    visit2->updateTreatments(newTreatmentsForVisit2);
+    visit3->updateTreatments({});
+
+    EXPECT_EQ(visit1->getTreatments(), newTreatmentsForVisit1);
+    EXPECT_EQ(visit2->getTreatments(), newTreatmentsForVisit2);
+    EXPECT_TRUE(visit3->getTreatments().empty());
 }
 
 } // namespace

--- a/src/tests/ut/visit/visit_test.cpp
+++ b/src/tests/ut/visit/visit_test.cpp
@@ -8,53 +8,52 @@ namespace
 {
 TEST_F(VisitTestsFixture, ExtentDemo)
 {
-    auto content = Visit::getExtent().size();
-    auto expected = 3;
+    const auto& content = Visit::getExtent().size();
+    const auto& expected = 3;
     EXPECT_EQ(content, expected);
 }
 
 TEST_F(VisitTestsFixture, AssociationDemo)
 {
-    auto content = visit1->getDoctorAssociation()->getLastName();
-    auto expected = "Tracz";
+    const auto& content = visit1->getDoctorAssociation()->getLastName();
+    const auto& expected = "Tracz";
     EXPECT_EQ(content, expected);
 }
 
 TEST_F(VisitTestsFixture, AssociationDemo2)
 {
-    auto content = doc2->getVisitAssociations().begin()->get()->getVisitInformation();
-    auto expected = "Tworze klub ninja!";
+    const auto& content = doc2->getVisitAssociations().begin()->get()->getVisitInformation();
+    const auto& expected = "Tworze klub ninja!";
     EXPECT_EQ(content, expected);
 }
 
 TEST_F(VisitTestsFixture, AssociationDemo3)
 {
     std::string content;
-    auto associations = doc2->getVisitAssociations();
+    const auto& associations = doc2->getVisitAssociations();
 
-    auto expected = "I w klubie sa sami fajni ludzie";
+    const auto& expected = "I w klubie sa sami fajni ludzie";
 
-    EXPECT_TRUE(std::ranges::any_of(
-        associations, [&expected](const auto& visitSPtr) { return visitSPtr->getVisitInformation() == expected; }));
+    bool associationsContainExpectedVisitInformation = std::ranges::any_of(
+        associations, [&expected](const auto& visitSPtr) { return visitSPtr->getVisitInformation() == expected; });
+
+    EXPECT_TRUE(associationsContainExpectedVisitInformation);
 }
 
 TEST_F(VisitTestsFixture, UpdateTreatmentsShouldReplacePreviouslyStoredTreatments)
 {
-    auto visitOneTreatmentsBefore = visit1->getTreatments();
-    auto visitTwoTreatmentsBefore = visit2->getTreatments();
-    auto visitThreeTreatmentsBefore = visit3->getTreatments();
-    // initial asserts
+    const auto& visitOneTreatmentsBefore = visit1->getTreatments();
+    const auto& visitTwoTreatmentsBefore = visit2->getTreatments();
+    const auto& visitThreeTreatmentsBefore = visit3->getTreatments();
     ASSERT_TRUE(visitOneTreatmentsBefore.empty());
     ASSERT_EQ(visitTwoTreatmentsBefore, std::vector{Treatment::TeethWhitening});
     ASSERT_EQ(visitThreeTreatmentsBefore,
               (std::vector{Treatment::TeethCleaning, Treatment::RootCanal, Treatment::ToothExtraction}));
 
-    // update treatments for visit
     std::vector newTreatmentsForVisit1 = {Treatment::GumSurgery};
     std::vector newTreatmentsForVisit2 = {Treatment::DentalFilling, Treatment::DentalSealants};
-    visit1->updateTreatments(newTreatmentsForVisit1);
-    visit2->updateTreatments(newTreatmentsForVisit2);
-    visit3->updateTreatments({});
+
+    updateVisitTreatments(newTreatmentsForVisit1, newTreatmentsForVisit2, {});
 
     EXPECT_EQ(visit1->getTreatments(), newTreatmentsForVisit1);
     EXPECT_EQ(visit2->getTreatments(), newTreatmentsForVisit2);

--- a/src/tests/ut/visit/visit_test.hpp
+++ b/src/tests/ut/visit/visit_test.hpp
@@ -5,7 +5,7 @@
 
 class Doctor;
 
-struct AssociationTest : ::testing::Test
+struct VisitTestsFixture : ::testing::Test
 {
     std::shared_ptr<Doctor> doc1{std::make_shared<Doctor>("Janusz", "Tracz", "1234")};
     std::shared_ptr<Doctor> doc2{std::make_shared<Doctor>("Lukasz", "Ziobron", "123456")};
@@ -14,11 +14,11 @@ struct AssociationTest : ::testing::Test
     std::shared_ptr<Visit> visit2;
     std::shared_ptr<Visit> visit3;
 
-    AssociationTest()
+    VisitTestsFixture()
     {
         visit1 = Visit::createVisit(doc1);
-        visit2 = Visit::createVisit(doc2);
-        visit3 = Visit::createVisit(doc2);
+        visit2 = Visit::createVisit(doc2, {Treatment::TeethWhitening});
+        visit3 = Visit::createVisit(doc2, {Treatment::TeethCleaning, Treatment::RootCanal, Treatment::ToothExtraction});
 
         visit2->setVisitInformation("Tworze klub ninja!");
         visit3->setVisitInformation("I w klubie sa sami fajni ludzie");

--- a/src/tests/ut/visit/visit_test.hpp
+++ b/src/tests/ut/visit/visit_test.hpp
@@ -5,8 +5,9 @@
 
 class Doctor;
 
-struct VisitTestsFixture : ::testing::Test
+class VisitTestsFixture : public ::testing::Test
 {
+  protected:
     std::shared_ptr<Doctor> doc1{std::make_shared<Doctor>("Janusz", "Tracz", "1234")};
     std::shared_ptr<Doctor> doc2{std::make_shared<Doctor>("Lukasz", "Ziobron", "123456")};
 
@@ -22,5 +23,14 @@ struct VisitTestsFixture : ::testing::Test
 
         visit2->setVisitInformation("Tworze klub ninja!");
         visit3->setVisitInformation("I w klubie sa sami fajni ludzie");
+    }
+
+    void updateVisitTreatments(const std::vector<Treatment>& visit_1_replacing_treatments,
+                               const std::vector<Treatment>& visit_2_replacing_treatments,
+                               const std::vector<Treatment>& visit_3_replacing_treatments)
+    {
+        visit1->updateTreatments(visit_1_replacing_treatments);
+        visit2->updateTreatments(visit_2_replacing_treatments);
+        visit3->updateTreatments(visit_3_replacing_treatments);
     }
 };


### PR DESCRIPTION
Introduced Treatment enum class for use in Visit.

Some fix in visit tests was necessary - test behaved randomly, which did not reveal itself until completely unrelated tests for enum where added. 