### PR TITLE
37 create reserve queue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:mantic as BUILD
 ENV PROJECT_NAME=desktop-business-app
 
 RUN apt update -y && \
-    apt install -y libgtest-dev cmake make g++ && \
+    apt install -y libgtest-dev libgmock-dev cmake make g++ && \
     apt install -y qt6-base-dev && \
     apt install -y libgl1-mesa-dev && \
     apt install -y libssl-dev && \

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ TBD...
 ### Prerequisites
 
 - Docker
-- Google Test (including gmock)
+- Google Test and Google Mock
 - C++20
 - clang-format (recommended minimum ver. 17)
 - OpenSSL

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ TBD...
 ### Prerequisites
 
 - Docker
-- Google Test
+- Google Test (including gmock)
 - C++20
 - clang-format (recommended minimum ver. 17)
 - OpenSSL

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -6,6 +6,7 @@ add_subdirectory(login)
 add_subdirectory(patient)
 add_subdirectory(person)
 add_subdirectory(receptionist)
+add_subdirectory(reserve_queue)
 add_subdirectory(visit)
 add_subdirectory(product)
 add_subdirectory(room)
@@ -28,6 +29,7 @@ target_link_libraries(${PROJECT_NAME} PRIVATE Qt6::Widgets
                                               person-lib
                                               product-lib
                                               receptionist-lib
+                                              reserve_queue-lib
                                               room-lib
                                               warehouse-lib
                                               visit-lib)

--- a/src/app/reserve_queue/CMakeLists.txt
+++ b/src/app/reserve_queue/CMakeLists.txt
@@ -1,0 +1,4 @@
+add_library(reserve_queue-lib reserve_queue.cpp)
+
+target_compile_options(reserve_queue-lib PRIVATE -Werror -Wall -Wextra -pedantic)
+target_include_directories(reserve_queue-lib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/app/reserve_queue/reserve_queue.cpp
+++ b/src/app/reserve_queue/reserve_queue.cpp
@@ -3,71 +3,61 @@
 
 bool ReserveQueue::addPatientToQueue(Treatment treatment, const std::shared_ptr<Patient>& patient)
 {
-    return addPatientIfNotPresent(treatment_queue_[treatment], patient);
+    return addPatientIfNotPresent(treatment_queues_[treatment], patient);
 }
 
 bool ReserveQueue::addPatientToQueue(const std::shared_ptr<Doctor>& doctor, const std::shared_ptr<Patient>& patient)
 {
-    return addPatientIfNotPresent(doctor_queue_[doctor], patient);
+    return addPatientIfNotPresent(doctor_queues_[doctor], patient);
 }
 
 void ReserveQueue::removePatientFromQueue(Treatment treatment, const std::shared_ptr<Patient>& patient)
 {
-    auto& patients_queued = treatment_queue_[treatment];
+    auto& patients_queued = treatment_queues_[treatment];
 
     removePatientFromQueue(patients_queued, patient);
 
     if (patients_queued.empty())
     {
-        treatment_queue_.erase(treatment);
+        treatment_queues_.erase(treatment);
     }
 }
 
 void ReserveQueue::removePatientFromQueue(const std::shared_ptr<Doctor>& doctor,
                                           const std::shared_ptr<Patient>& patient)
 {
-    auto& patients_queued = doctor_queue_[doctor];
+    auto& patients_queued = doctor_queues_[doctor];
 
     removePatientFromQueue(patients_queued, patient);
 
     if (patients_queued.empty())
     {
-        doctor_queue_.erase(doctor);
+        doctor_queues_.erase(doctor);
     }
 }
 
 ReserveQueue::PatientQueueType ReserveQueue::getQueuedPatients(Treatment treatment) const
 {
-    auto queued_patients = treatment_queue_.find(treatment);
+    auto queued_patients = treatment_queues_.find(treatment);
 
-    return queued_patients != treatment_queue_.end() ? queued_patients->second : PatientQueueType{};
+    return queued_patients != treatment_queues_.end() ? queued_patients->second : PatientQueueType{};
 }
 
 ReserveQueue::PatientQueueType ReserveQueue::getQueuedPatients(const std::shared_ptr<Doctor>& doctor) const
 {
-    auto queued_patients = doctor_queue_.find(doctor);
+    auto queued_patients = doctor_queues_.find(doctor);
 
-    return queued_patients != doctor_queue_.end() ? queued_patients->second : PatientQueueType{};
+    return queued_patients != doctor_queues_.end() ? queued_patients->second : PatientQueueType{};
 }
 
-std::vector<Treatment> ReserveQueue::treatmentsHavingQueue() const
+std::unordered_map<Treatment, ReserveQueue::PatientQueueType> ReserveQueue::getTreatmentQueues() const
 {
-    std::vector<Treatment> awaiting_treatments;
-    awaiting_treatments.reserve(treatment_queue_.size());
-    std::ranges::transform(treatment_queue_, std::back_inserter(awaiting_treatments),
-                           [](const auto& key_val_pair) { return key_val_pair.first; });
-
-    return awaiting_treatments;
+    return treatment_queues_;
 }
 
-std::vector<std::shared_ptr<Doctor>> ReserveQueue::doctorsHavingQueue() const
+std::unordered_map<std::shared_ptr<Doctor>, ReserveQueue::PatientQueueType> ReserveQueue::getDoctorQueues() const
 {
-    std::vector<std::shared_ptr<Doctor>> awaited_doctors;
-    awaited_doctors.reserve(doctor_queue_.size());
-    std::ranges::transform(doctor_queue_, std::back_inserter(awaited_doctors),
-                           [](const auto& key_val_pair) { return key_val_pair.first; });
-
-    return awaited_doctors;
+    return doctor_queues_;
 }
 
 bool ReserveQueue::addPatientIfNotPresent(ReserveQueue::PatientQueueType& patients_queued,

--- a/src/app/reserve_queue/reserve_queue.cpp
+++ b/src/app/reserve_queue/reserve_queue.cpp
@@ -1,0 +1,95 @@
+#include "reserve_queue.hpp"
+#include <algorithm>
+
+namespace
+{
+bool addPatientIfNotPresent(ReserveQueue::PatientQueueType& patients_queued, const std::shared_ptr<Patient>& patient)
+{
+    auto patient_iterator = std::ranges::find(patients_queued, patient);
+
+    if (patient_iterator == patients_queued.end())
+    {
+        patients_queued.emplace_back(patient);
+
+        return true;
+    }
+
+    return false;
+}
+
+void removePatientFromQueue(ReserveQueue::PatientQueueType& patients_queued, const std::shared_ptr<Patient>& patient)
+{
+    if (auto patientSearched = std::ranges::find(patients_queued, patient); patientSearched != patients_queued.end())
+    {
+        patients_queued.erase(patientSearched);
+    }
+}
+} // namespace
+
+bool ReserveQueue::addAwaitingPatient(Treatment treatment, const std::shared_ptr<Patient>& patient)
+{
+    return addPatientIfNotPresent(treatment_queue_[treatment], patient);
+}
+
+bool ReserveQueue::addAwaitingPatient(const std::shared_ptr<Doctor>& doctor, const std::shared_ptr<Patient>& patient)
+{
+    return addPatientIfNotPresent(doctor_queue_[doctor], patient);
+}
+
+void ReserveQueue::removeAwaitingPatient(Treatment treatment, const std::shared_ptr<Patient>& patient)
+{
+    auto& patients_queued = treatment_queue_[treatment];
+
+    removePatientFromQueue(patients_queued, patient);
+
+    if (patients_queued.empty())
+    {
+        treatment_queue_.erase(treatment);
+    }
+}
+
+void ReserveQueue::removeAwaitingPatient(const std::shared_ptr<Doctor>& doctor, const std::shared_ptr<Patient>& patient)
+{
+    auto& patients_queued = doctor_queue_[doctor];
+
+    removePatientFromQueue(patients_queued, patient);
+
+    if (patients_queued.empty())
+    {
+        doctor_queue_.erase(doctor);
+    }
+}
+
+ReserveQueue::PatientQueueType ReserveQueue::awaitingPatients(Treatment treatment) const
+{
+    auto queued_patients = treatment_queue_.find(treatment);
+
+    return queued_patients != treatment_queue_.end() ? queued_patients->second : PatientQueueType{};
+}
+
+ReserveQueue::PatientQueueType ReserveQueue::awaitingPatients(const std::shared_ptr<Doctor>& doctor) const
+{
+    auto queued_patients = doctor_queue_.find(doctor);
+
+    return queued_patients != doctor_queue_.end() ? queued_patients->second : PatientQueueType{};
+}
+
+std::vector<Treatment> ReserveQueue::treatmentsHavingQueue() const
+{
+    std::vector<Treatment> awaiting_treatments;
+    awaiting_treatments.reserve(treatment_queue_.size());
+    std::ranges::transform(treatment_queue_, std::back_inserter(awaiting_treatments),
+                           [](const auto& key_val_pair) { return key_val_pair.first; });
+
+    return awaiting_treatments;
+}
+
+std::vector<std::shared_ptr<Doctor>> ReserveQueue::doctorsHavingQueue() const
+{
+    std::vector<std::shared_ptr<Doctor>> awaited_doctors;
+    awaited_doctors.reserve(doctor_queue_.size());
+    std::ranges::transform(doctor_queue_, std::back_inserter(awaited_doctors),
+                           [](const auto& key_val_pair) { return key_val_pair.first; });
+
+    return awaited_doctors;
+}

--- a/src/app/reserve_queue/reserve_queue.cpp
+++ b/src/app/reserve_queue/reserve_queue.cpp
@@ -1,42 +1,17 @@
 #include "reserve_queue.hpp"
 #include <algorithm>
 
-namespace
-{
-bool addPatientIfNotPresent(ReserveQueue::PatientQueueType& patients_queued, const std::shared_ptr<Patient>& patient)
-{
-    auto patient_iterator = std::ranges::find(patients_queued, patient);
-
-    if (patient_iterator == patients_queued.end())
-    {
-        patients_queued.emplace_back(patient);
-
-        return true;
-    }
-
-    return false;
-}
-
-void removePatientFromQueue(ReserveQueue::PatientQueueType& patients_queued, const std::shared_ptr<Patient>& patient)
-{
-    if (auto patientSearched = std::ranges::find(patients_queued, patient); patientSearched != patients_queued.end())
-    {
-        patients_queued.erase(patientSearched);
-    }
-}
-} // namespace
-
-bool ReserveQueue::addAwaitingPatient(Treatment treatment, const std::shared_ptr<Patient>& patient)
+bool ReserveQueue::addPatientToQueue(Treatment treatment, const std::shared_ptr<Patient>& patient)
 {
     return addPatientIfNotPresent(treatment_queue_[treatment], patient);
 }
 
-bool ReserveQueue::addAwaitingPatient(const std::shared_ptr<Doctor>& doctor, const std::shared_ptr<Patient>& patient)
+bool ReserveQueue::addPatientToQueue(const std::shared_ptr<Doctor>& doctor, const std::shared_ptr<Patient>& patient)
 {
     return addPatientIfNotPresent(doctor_queue_[doctor], patient);
 }
 
-void ReserveQueue::removeAwaitingPatient(Treatment treatment, const std::shared_ptr<Patient>& patient)
+void ReserveQueue::removePatientFromQueue(Treatment treatment, const std::shared_ptr<Patient>& patient)
 {
     auto& patients_queued = treatment_queue_[treatment];
 
@@ -48,7 +23,8 @@ void ReserveQueue::removeAwaitingPatient(Treatment treatment, const std::shared_
     }
 }
 
-void ReserveQueue::removeAwaitingPatient(const std::shared_ptr<Doctor>& doctor, const std::shared_ptr<Patient>& patient)
+void ReserveQueue::removePatientFromQueue(const std::shared_ptr<Doctor>& doctor,
+                                          const std::shared_ptr<Patient>& patient)
 {
     auto& patients_queued = doctor_queue_[doctor];
 
@@ -60,14 +36,14 @@ void ReserveQueue::removeAwaitingPatient(const std::shared_ptr<Doctor>& doctor, 
     }
 }
 
-ReserveQueue::PatientQueueType ReserveQueue::awaitingPatients(Treatment treatment) const
+ReserveQueue::PatientQueueType ReserveQueue::getQueuedPatients(Treatment treatment) const
 {
     auto queued_patients = treatment_queue_.find(treatment);
 
     return queued_patients != treatment_queue_.end() ? queued_patients->second : PatientQueueType{};
 }
 
-ReserveQueue::PatientQueueType ReserveQueue::awaitingPatients(const std::shared_ptr<Doctor>& doctor) const
+ReserveQueue::PatientQueueType ReserveQueue::getQueuedPatients(const std::shared_ptr<Doctor>& doctor) const
 {
     auto queued_patients = doctor_queue_.find(doctor);
 
@@ -92,4 +68,28 @@ std::vector<std::shared_ptr<Doctor>> ReserveQueue::doctorsHavingQueue() const
                            [](const auto& key_val_pair) { return key_val_pair.first; });
 
     return awaited_doctors;
+}
+
+bool ReserveQueue::addPatientIfNotPresent(ReserveQueue::PatientQueueType& patients_queued,
+                                          const std::shared_ptr<Patient>& patient)
+{
+    auto patient_iterator = std::ranges::find(patients_queued, patient);
+
+    if (patient_iterator == patients_queued.end())
+    {
+        patients_queued.emplace_back(patient);
+
+        return true;
+    }
+
+    return false;
+}
+
+void ReserveQueue::removePatientFromQueue(ReserveQueue::PatientQueueType& patients_queued,
+                                          const std::shared_ptr<Patient>& patient)
+{
+    if (auto patientSearched = std::ranges::find(patients_queued, patient); patientSearched != patients_queued.end())
+    {
+        patients_queued.erase(patientSearched);
+    }
 }

--- a/src/app/reserve_queue/reserve_queue.hpp
+++ b/src/app/reserve_queue/reserve_queue.hpp
@@ -15,8 +15,8 @@ class ReserveQueue
 
     PatientQueueType getQueuedPatients(Treatment treatment) const;
     PatientQueueType getQueuedPatients(const std::shared_ptr<Doctor>& doctor) const;
-    std::vector<Treatment> treatmentsHavingQueue() const;
-    std::vector<std::shared_ptr<Doctor>> doctorsHavingQueue() const;
+    std::unordered_map<Treatment, PatientQueueType> getTreatmentQueues() const;
+    std::unordered_map<std::shared_ptr<Doctor>, PatientQueueType> getDoctorQueues() const;
 
     bool addPatientToQueue(Treatment treatment, const std::shared_ptr<Patient>& patient);
     bool addPatientToQueue(const std::shared_ptr<Doctor>& doctor, const std::shared_ptr<Patient>& patient);
@@ -29,6 +29,6 @@ class ReserveQueue
     void removePatientFromQueue(ReserveQueue::PatientQueueType& patients_queued,
                                 const std::shared_ptr<Patient>& patient);
 
-    std::unordered_map<Treatment, PatientQueueType> treatment_queue_;
-    std::unordered_map<std::shared_ptr<Doctor>, PatientQueueType> doctor_queue_;
+    std::unordered_map<Treatment, PatientQueueType> treatment_queues_;
+    std::unordered_map<std::shared_ptr<Doctor>, PatientQueueType> doctor_queues_;
 };

--- a/src/app/reserve_queue/reserve_queue.hpp
+++ b/src/app/reserve_queue/reserve_queue.hpp
@@ -26,5 +26,4 @@ class ReserveQueue
   private:
     std::unordered_map<Treatment, PatientQueueType> treatment_queue_;
     std::unordered_map<std::shared_ptr<Doctor>, PatientQueueType> doctor_queue_;
-
 };

--- a/src/app/reserve_queue/reserve_queue.hpp
+++ b/src/app/reserve_queue/reserve_queue.hpp
@@ -13,17 +13,22 @@ class ReserveQueue
   public:
     using PatientQueueType = std::vector<std::shared_ptr<Patient>>;
 
-    PatientQueueType awaitingPatients(Treatment treatment) const;
-    PatientQueueType awaitingPatients(const std::shared_ptr<Doctor>& doctor) const;
+    PatientQueueType getQueuedPatients(Treatment treatment) const;
+    PatientQueueType getQueuedPatients(const std::shared_ptr<Doctor>& doctor) const;
     std::vector<Treatment> treatmentsHavingQueue() const;
     std::vector<std::shared_ptr<Doctor>> doctorsHavingQueue() const;
 
-    bool addAwaitingPatient(Treatment treatment, const std::shared_ptr<Patient>& patient);
-    bool addAwaitingPatient(const std::shared_ptr<Doctor>& doctor, const std::shared_ptr<Patient>& patient);
-    void removeAwaitingPatient(Treatment treatment, const std::shared_ptr<Patient>& patient);
-    void removeAwaitingPatient(const std::shared_ptr<Doctor>& doctor, const std::shared_ptr<Patient>& patient);
+    bool addPatientToQueue(Treatment treatment, const std::shared_ptr<Patient>& patient);
+    bool addPatientToQueue(const std::shared_ptr<Doctor>& doctor, const std::shared_ptr<Patient>& patient);
+    void removePatientFromQueue(Treatment treatment, const std::shared_ptr<Patient>& patient);
+    void removePatientFromQueue(const std::shared_ptr<Doctor>& doctor, const std::shared_ptr<Patient>& patient);
 
   private:
+    bool addPatientIfNotPresent(ReserveQueue::PatientQueueType& patients_queued,
+                                const std::shared_ptr<Patient>& patient);
+    void removePatientFromQueue(ReserveQueue::PatientQueueType& patients_queued,
+                                const std::shared_ptr<Patient>& patient);
+
     std::unordered_map<Treatment, PatientQueueType> treatment_queue_;
     std::unordered_map<std::shared_ptr<Doctor>, PatientQueueType> doctor_queue_;
 };

--- a/src/app/reserve_queue/reserve_queue.hpp
+++ b/src/app/reserve_queue/reserve_queue.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <memory>
+#include <unordered_map>
+#include <vector>
+
+class Doctor;
+class Patient;
+enum class Treatment : uint32_t;
+
+class ReserveQueue
+{
+  public:
+    using PatientQueueType = std::vector<std::shared_ptr<Patient>>;
+
+    PatientQueueType awaitingPatients(Treatment treatment) const;
+    PatientQueueType awaitingPatients(const std::shared_ptr<Doctor>& doctor) const;
+    std::vector<Treatment> treatmentsHavingQueue() const;
+    std::vector<std::shared_ptr<Doctor>> doctorsHavingQueue() const;
+
+    bool addAwaitingPatient(Treatment treatment, const std::shared_ptr<Patient>& patient);
+    bool addAwaitingPatient(const std::shared_ptr<Doctor>& doctor, const std::shared_ptr<Patient>& patient);
+    void removeAwaitingPatient(Treatment treatment, const std::shared_ptr<Patient>& patient);
+    void removeAwaitingPatient(const std::shared_ptr<Doctor>& doctor, const std::shared_ptr<Patient>& patient);
+
+  private:
+    std::unordered_map<Treatment, PatientQueueType> treatment_queue_;
+    std::unordered_map<std::shared_ptr<Doctor>, PatientQueueType> doctor_queue_;
+
+};

--- a/src/app/visit/CMakeLists.txt
+++ b/src/app/visit/CMakeLists.txt
@@ -2,5 +2,7 @@ add_library(visit-lib visit.cpp
                       treatment.cpp)
 
 target_compile_options(visit-lib PRIVATE -Werror -Wall -Wextra -pedantic)
-target_link_libraries(visit-lib PRIVATE doctor-lib)
+target_link_libraries(visit-lib PRIVATE clinic-lib
+                                        doctor-lib
+                                        patient-lib)
 target_include_directories(visit-lib PUBLIC .)

--- a/src/app/visit/visit.cpp
+++ b/src/app/visit/visit.cpp
@@ -1,6 +1,6 @@
 #include "visit.hpp"
-#include "../clinic/clinic_facade.hpp"
-#include "../doctor/doctor.hpp"
+#include "clinic_facade.hpp"
+#include "patient.hpp"
 
 Visit::Visit(const std::shared_ptr<Doctor>& doctor, const std::vector<Treatment>& treatments)
     : doctor_{doctor}, patient_{}, treatments_{std::move(treatments)}, visit_information_{}

--- a/src/app/visit/visit.hpp
+++ b/src/app/visit/visit.hpp
@@ -1,7 +1,5 @@
 #pragma once
 
-#include "../doctor/doctor.hpp"
-#include "../patient/patient.hpp"
 #include "treatment.hpp"
 #include <memory>
 #include <set>

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -5,6 +5,7 @@ set(UT_SOURCES ut/login/login_test.cpp
                ut/patient/patient_test.cpp
                ut/receptionist/receptionist_test.cpp
                ut/receptionist/shift_test.cpp
+               ut/reserve_queue/reserve_queue_test.cpp
                ut/visit/treatment_test.cpp
                ut/visit/visit_test.cpp
 )
@@ -12,18 +13,23 @@ set(UT_SOURCES ut/login/login_test.cpp
 
 include(GoogleTest)
 
+add_subdirectory(test_utils)
+
 add_executable(${PROJECT_NAME}-tests ${UT_SOURCES})
 
 target_compile_options(${PROJECT_NAME}-tests PRIVATE -Werror -Wall -Wextra -pedantic)
 
 target_link_libraries(${PROJECT_NAME}-tests PRIVATE
                                             GTest::gtest_main
+                                            GTest::gmock_main
                                             clinic-lib
                                             doctor-lib
                                             login-lib
                                             patient-lib
                                             person-lib
                                             receptionist-lib
+                                            reserve_queue-lib
+                                            test_utils-lib
                                             visit-lib
 )
 
@@ -34,3 +40,4 @@ add_test(NAME ${PROJECT_NAME}-tests COMMAND ${PROJECT_NAME}-tests WORKING_DIRECT
 add_subdirectory(ut/warehouse)
 add_subdirectory(ut/medicine)
 add_subdirectory(ut/equipment)
+add_subdirectory(ut/reserve_queue)

--- a/src/tests/test_utils/CMakeLists.txt
+++ b/src/tests/test_utils/CMakeLists.txt
@@ -1,0 +1,6 @@
+add_library(test_utils-lib test_utils.cpp)
+
+target_compile_options(test_utils-lib PRIVATE -Werror -Wall -Wextra -pedantic)
+target_include_directories(test_utils-lib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries(test_utils-lib PRIVATE clinic-lib)
+

--- a/src/tests/test_utils/test_utils.cpp
+++ b/src/tests/test_utils/test_utils.cpp
@@ -1,0 +1,25 @@
+#include "test_utils.hpp"
+#include "clinic_facade.hpp"
+
+void cleanupClinic()
+{
+    for (const auto& visit : Clinic::getVisits())
+    {
+        Clinic::removeVisit(visit);
+    }
+
+    for (const auto& doctor : Clinic::getDoctors())
+    {
+        Clinic::removeDoctor(doctor);
+    }
+
+    for (const auto& receptionist : Clinic::getReceptionists())
+    {
+        Clinic::removeReceptionist(receptionist);
+    }
+
+    for (const auto& patient : Clinic::getPatients())
+    {
+        Clinic::removePatient(patient);
+    }
+}

--- a/src/tests/test_utils/test_utils.hpp
+++ b/src/tests/test_utils/test_utils.hpp
@@ -1,0 +1,3 @@
+#pragma once
+
+void cleanupClinic();

--- a/src/tests/ut/clinic/clinic_test.hpp
+++ b/src/tests/ut/clinic/clinic_test.hpp
@@ -1,30 +1,13 @@
 #pragma once
 
 #include "clinic_facade.hpp"
+#include "test_utils.hpp"
 #include "gtest/gtest.h"
 
 class ClinicTestFixture : public ::testing::Test
 {
     void TearDown() override
     {
-        for (const auto& visit : Clinic::getVisits())
-        {
-            Clinic::removeVisit(visit);
-        }
-
-        for (const auto& doctor : Clinic::getDoctors())
-        {
-            Clinic::removeDoctor(doctor);
-        }
-
-        for (const auto& receptionist : Clinic::getReceptionists())
-        {
-            Clinic::removeReceptionist(receptionist);
-        }
-
-        for (const auto& patient : Clinic::getPatients())
-        {
-            Clinic::removePatient(patient);
-        }
+        cleanupClinic();
     }
 };

--- a/src/tests/ut/patient/patient_test.hpp
+++ b/src/tests/ut/patient/patient_test.hpp
@@ -2,6 +2,7 @@
 
 #include "clinic_facade.hpp"
 #include "patient.hpp"
+#include "test_utils.hpp"
 #include "gtest/gtest.h"
 
 class PatientTestFixture : public ::testing::Test
@@ -9,25 +10,7 @@ class PatientTestFixture : public ::testing::Test
 
     void TearDown() override
     {
-        for (const auto& visit : Clinic::getVisits())
-        {
-            Clinic::removeVisit(visit);
-        }
-
-        for (const auto& doctor : Clinic::getDoctors())
-        {
-            Clinic::removeDoctor(doctor);
-        }
-
-        for (const auto& receptionist : Clinic::getReceptionists())
-        {
-            Clinic::removeReceptionist(receptionist);
-        }
-
-        for (const auto& patient : Clinic::getPatients())
-        {
-            Clinic::removePatient(patient);
-        }
+        cleanupClinic();
     }
 
   protected:

--- a/src/tests/ut/receptionist/receptionist_test.hpp
+++ b/src/tests/ut/receptionist/receptionist_test.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "clinic_facade.hpp"
+#include "test_utils.hpp"
 #include "gtest/gtest.h"
 
 class ReceptionistTestFixture : public ::testing::Test
@@ -8,23 +9,6 @@ class ReceptionistTestFixture : public ::testing::Test
   protected:
     void TearDown() override
     {
-        for (const auto& visit : Clinic::getVisits())
-        {
-            Clinic::removeVisit(visit);
-        }
-
-        for (const auto& doctor : Clinic::getDoctors())
-        {
-            Clinic::removeDoctor(doctor);
-        }
-        for (const auto& receptionist : Clinic::getReceptionists())
-        {
-            Clinic::removeReceptionist(receptionist);
-        }
-
-        for (const auto& patient : Clinic::getPatients())
-        {
-            Clinic::removePatient(patient);
-        }
+        cleanupClinic();
     }
 };

--- a/src/tests/ut/reserve_queue/CMakeLists.txt
+++ b/src/tests/ut/reserve_queue/CMakeLists.txt
@@ -1,0 +1,14 @@
+add_executable(reserve_queue-ut reserve_queue_test.cpp)
+
+target_compile_options(reserve_queue-ut PRIVATE -Werror -Wall -Wextra -pedantic)
+target_link_libraries(reserve_queue-ut PRIVATE GTest::gtest_main
+                                               GTest::gmock_main
+                                               clinic-lib
+                                               doctor-lib
+                                               person-lib
+                                               reserve_queue-lib
+                                               test_utils-lib
+                                               visit-lib)
+
+include(GoogleTest)
+gtest_discover_tests(reserve_queue-ut)

--- a/src/tests/ut/reserve_queue/reserve_queue_test.cpp
+++ b/src/tests/ut/reserve_queue/reserve_queue_test.cpp
@@ -1,0 +1,412 @@
+#include "reserve_queue_test.hpp"
+
+#include "gmock/gmock.h"
+
+namespace
+{
+using ::testing::ElementsAre;
+using ::testing::UnorderedElementsAre;
+
+class AddAwaitingPatientShould : public ReserveQueueFixture
+{
+};
+
+TEST_F(AddAwaitingPatientShould, EnqueuePatientsForTreatmentInCorrectOrder)
+{
+    Treatment filling_treatment{Treatment::DentalFilling};
+    sut_.addAwaitingPatient(filling_treatment, patients_[0]);
+    sut_.addAwaitingPatient(filling_treatment, patients_[1]);
+    sut_.addAwaitingPatient(filling_treatment, patients_[2]);
+    sut_.addAwaitingPatient(filling_treatment, patients_[3]);
+
+    Treatment tooth_extraction_treatment{Treatment::ToothExtraction};
+    sut_.addAwaitingPatient(tooth_extraction_treatment, patients_[3]);
+    sut_.addAwaitingPatient(tooth_extraction_treatment, patients_[0]);
+    sut_.addAwaitingPatient(tooth_extraction_treatment, patients_[1]);
+
+    const auto filling_treatment_queued_patients = sut_.awaitingPatients(filling_treatment);
+    const auto tooth_extraction_queed_patients = sut_.awaitingPatients(tooth_extraction_treatment);
+
+    EXPECT_THAT(filling_treatment_queued_patients, ElementsAre(patients_[0], patients_[1], patients_[2], patients_[3]));
+    EXPECT_THAT(tooth_extraction_queed_patients, ElementsAre(patients_[3], patients_[0], patients_[1]));
+}
+
+TEST_F(AddAwaitingPatientShould, NotEnQueuePatientsIfAlreadyEnqueuedForSpecificTreatment)
+{
+    Treatment tooth_extraction_treatment{Treatment::ToothExtraction};
+    sut_.addAwaitingPatient(tooth_extraction_treatment, patients_[3]);
+    sut_.addAwaitingPatient(tooth_extraction_treatment, patients_[0]);
+
+    sut_.addAwaitingPatient(tooth_extraction_treatment, patients_[3]);
+    sut_.addAwaitingPatient(tooth_extraction_treatment, patients_[0]);
+
+    const auto tooth_extraction_queed_patients = sut_.awaitingPatients(tooth_extraction_treatment);
+
+    EXPECT_THAT(tooth_extraction_queed_patients, ElementsAre(patients_[3], patients_[0]));
+}
+
+TEST_F(AddAwaitingPatientShould, EnqueuePatientsForDoctorInCorrectOrder)
+{
+    // first doctor queue
+    sut_.addAwaitingPatient(doctors_[0], patients_[3]);
+    sut_.addAwaitingPatient(doctors_[0], patients_[2]);
+    sut_.addAwaitingPatient(doctors_[0], patients_[1]);
+    sut_.addAwaitingPatient(doctors_[0], patients_[0]);
+    // second doctor queue
+    sut_.addAwaitingPatient(doctors_[1], patients_[2]);
+    sut_.addAwaitingPatient(doctors_[1], patients_[0]);
+    // third doctor queue
+    sut_.addAwaitingPatient(doctors_[2], patients_[1]);
+    sut_.addAwaitingPatient(doctors_[2], patients_[0]);
+    sut_.addAwaitingPatient(doctors_[2], patients_[3]);
+    sut_.addAwaitingPatient(doctors_[2], patients_[2]);
+
+    const auto first_doctor_queued_patients = sut_.awaitingPatients(doctors_[0]);
+    const auto second_doctor_queued_patients = sut_.awaitingPatients(doctors_[1]);
+    const auto third_doctor_queued_patients = sut_.awaitingPatients(doctors_[2]);
+
+    EXPECT_THAT(first_doctor_queued_patients, ElementsAre(patients_[3], patients_[2], patients_[1], patients_[0]));
+    EXPECT_THAT(second_doctor_queued_patients, ElementsAre(patients_[2], patients_[0]));
+    EXPECT_THAT(third_doctor_queued_patients, ElementsAre(patients_[1], patients_[0], patients_[3], patients_[2]));
+}
+
+TEST_F(AddAwaitingPatientShould, NotEnQueuePatientsIfAlreadyEnqueuedForSpecificDoctor)
+{
+    sut_.addAwaitingPatient(doctors_[1], patients_[2]);
+    sut_.addAwaitingPatient(doctors_[1], patients_[1]);
+    sut_.addAwaitingPatient(doctors_[1], patients_[0]);
+    sut_.addAwaitingPatient(doctors_[1], patients_[2]);
+    sut_.addAwaitingPatient(doctors_[1], patients_[0]);
+
+    const auto doctor_queued_patients = sut_.awaitingPatients(doctors_[1]);
+
+    EXPECT_THAT(doctor_queued_patients, ElementsAre(patients_[2], patients_[1], patients_[0]));
+}
+
+class RemoveAwaitingPatientShould : public ReserveQueueFixture
+{
+};
+
+TEST_F(RemoveAwaitingPatientShould, NotChangeTreatmentQueueIfPatientNotPresentInQueue)
+{
+    Treatment filling_treatment{Treatment::DentalFilling};
+    sut_.addAwaitingPatient(filling_treatment, patients_[0]);
+    sut_.addAwaitingPatient(filling_treatment, patients_[1]);
+    sut_.addAwaitingPatient(filling_treatment, patients_[2]);
+
+    Treatment tooth_extraction_treatment{Treatment::ToothExtraction};
+    sut_.addAwaitingPatient(tooth_extraction_treatment, patients_[3]);
+    sut_.addAwaitingPatient(tooth_extraction_treatment, patients_[0]);
+
+    const auto filling_treatment_patients_before = sut_.awaitingPatients(filling_treatment);
+    const auto tooth_extraction_patients_before = sut_.awaitingPatients(tooth_extraction_treatment);
+
+    ASSERT_THAT(filling_treatment_patients_before, ElementsAre(patients_[0], patients_[1], patients_[2]));
+    ASSERT_THAT(tooth_extraction_patients_before, ElementsAre(patients_[3], patients_[0]));
+
+    sut_.removeAwaitingPatient(filling_treatment, patients_[3]);
+    sut_.removeAwaitingPatient(tooth_extraction_treatment, patients_[1]);
+
+    const auto filling_treatment_patients_after = sut_.awaitingPatients(filling_treatment);
+    const auto tooth_extraction_patients_after = sut_.awaitingPatients(tooth_extraction_treatment);
+
+    EXPECT_EQ(filling_treatment_patients_before, filling_treatment_patients_after);
+    EXPECT_EQ(tooth_extraction_patients_before, tooth_extraction_patients_after);
+}
+
+TEST_F(RemoveAwaitingPatientShould, NotChangeDoctorQueueIfPatientNotPresentInQueue)
+{
+    // first doctor queue
+    sut_.addAwaitingPatient(doctors_[0], patients_[2]);
+    sut_.addAwaitingPatient(doctors_[0], patients_[1]);
+    // second doctor queue
+    sut_.addAwaitingPatient(doctors_[1], patients_[3]);
+    sut_.addAwaitingPatient(doctors_[1], patients_[0]);
+
+    const auto first_doctor_patients_before = sut_.awaitingPatients(doctors_[0]);
+    const auto second_doctor_patients_before = sut_.awaitingPatients(doctors_[1]);
+
+    ASSERT_THAT(first_doctor_patients_before, ElementsAre(patients_[2], patients_[1]));
+    ASSERT_THAT(second_doctor_patients_before, ElementsAre(patients_[3], patients_[0]));
+
+    sut_.removeAwaitingPatient(doctors_[0], patients_[3]);
+    sut_.removeAwaitingPatient(doctors_[1], patients_[1]);
+
+    const auto first_doctor_patients_after = sut_.awaitingPatients(doctors_[0]);
+    const auto second_doctor_patients_after = sut_.awaitingPatients(doctors_[1]);
+
+    EXPECT_EQ(first_doctor_patients_before, first_doctor_patients_after);
+    EXPECT_EQ(second_doctor_patients_before, second_doctor_patients_after);
+}
+
+TEST_F(RemoveAwaitingPatientShould, NotAddTreatmentKeyIfRemovalRequestedFromEmptyList)
+{
+    const auto treatments_awaiting_before = sut_.treatmentsHavingQueue();
+    ASSERT_TRUE(treatments_awaiting_before.empty());
+
+    sut_.removeAwaitingPatient(Treatment::DentalFilling, patients_[0]);
+    sut_.removeAwaitingPatient(Treatment::ToothExtraction, patients_[1]);
+    const auto treatments_awaiting_after_removal_attempts = sut_.treatmentsHavingQueue();
+
+    EXPECT_TRUE(treatments_awaiting_after_removal_attempts.empty());
+}
+
+TEST_F(RemoveAwaitingPatientShould, NotAddDoctorKeyIfRemovalRequestedFromEmptyList)
+{
+    const auto doctors_with_patients_awaiting_appointments_before = sut_.doctorsHavingQueue();
+    ASSERT_TRUE(doctors_with_patients_awaiting_appointments_before.empty());
+
+    sut_.removeAwaitingPatient(doctors_[0], patients_[0]);
+    sut_.removeAwaitingPatient(doctors_[1], patients_[1]);
+    const auto doctors_with_patients_awaiting_appointments_after_removal_attempts = sut_.doctorsHavingQueue();
+
+    EXPECT_TRUE(doctors_with_patients_awaiting_appointments_after_removal_attempts.empty());
+}
+
+TEST_F(RemoveAwaitingPatientShould, RemovePatientFromBeginningOfSpecificTreatmentQueue)
+{
+    Treatment filling_treatment{Treatment::DentalFilling};
+    sut_.addAwaitingPatient(filling_treatment, patients_[0]);
+    sut_.addAwaitingPatient(filling_treatment, patients_[1]);
+    sut_.addAwaitingPatient(filling_treatment, patients_[2]);
+    sut_.addAwaitingPatient(filling_treatment, patients_[3]);
+
+    const auto filling_treatment_patients_before = sut_.awaitingPatients(filling_treatment);
+
+    ASSERT_THAT(filling_treatment_patients_before, ElementsAre(patients_[0], patients_[1], patients_[2], patients_[3]));
+
+    sut_.removeAwaitingPatient(filling_treatment, patients_[0]);
+    const auto filling_treatment_patients_after = sut_.awaitingPatients(filling_treatment);
+
+    EXPECT_NE(filling_treatment_patients_before, filling_treatment_patients_after);
+    EXPECT_THAT(filling_treatment_patients_after, ElementsAre(patients_[1], patients_[2], patients_[3]));
+}
+
+TEST_F(RemoveAwaitingPatientShould, RemovePatientFromTheMiddleOfSpecificTreatmentQueue)
+{
+    Treatment filling_treatment{Treatment::DentalFilling};
+    sut_.addAwaitingPatient(filling_treatment, patients_[0]);
+    sut_.addAwaitingPatient(filling_treatment, patients_[1]);
+    sut_.addAwaitingPatient(filling_treatment, patients_[2]);
+    sut_.addAwaitingPatient(filling_treatment, patients_[3]);
+
+    const auto filling_treatment_patients_before = sut_.awaitingPatients(filling_treatment);
+
+    ASSERT_THAT(filling_treatment_patients_before, ElementsAre(patients_[0], patients_[1], patients_[2], patients_[3]));
+
+    sut_.removeAwaitingPatient(filling_treatment, patients_[1]);
+    sut_.removeAwaitingPatient(filling_treatment, patients_[2]);
+    const auto filling_treatment_patients_after = sut_.awaitingPatients(filling_treatment);
+
+    EXPECT_NE(filling_treatment_patients_before, filling_treatment_patients_after);
+    EXPECT_THAT(filling_treatment_patients_after, ElementsAre(patients_[0], patients_[3]));
+}
+
+TEST_F(RemoveAwaitingPatientShould, RemovePatientFromTheEndOfSpecificTreatmentQueue)
+{
+    Treatment filling_treatment{Treatment::DentalFilling};
+    sut_.addAwaitingPatient(filling_treatment, patients_[0]);
+    sut_.addAwaitingPatient(filling_treatment, patients_[1]);
+    sut_.addAwaitingPatient(filling_treatment, patients_[2]);
+    sut_.addAwaitingPatient(filling_treatment, patients_[3]);
+
+    const auto filling_treatment_patients_before = sut_.awaitingPatients(filling_treatment);
+
+    ASSERT_THAT(filling_treatment_patients_before, ElementsAre(patients_[0], patients_[1], patients_[2], patients_[3]));
+
+    sut_.removeAwaitingPatient(filling_treatment, patients_[3]);
+    const auto filling_treatment_patients_after = sut_.awaitingPatients(filling_treatment);
+
+    EXPECT_NE(filling_treatment_patients_before, filling_treatment_patients_after);
+    EXPECT_THAT(filling_treatment_patients_after, ElementsAre(patients_[0], patients_[1], patients_[2]));
+}
+
+TEST_F(RemoveAwaitingPatientShould, RemoveTreatmentKeyIfLastPatientAwaitingRemoved)
+{
+    Treatment filling_treatment{Treatment::DentalFilling};
+    sut_.addAwaitingPatient(filling_treatment, patients_[0]);
+    sut_.addAwaitingPatient(filling_treatment, patients_[1]);
+
+    Treatment tooth_extraction_treatment{Treatment::ToothExtraction};
+    sut_.addAwaitingPatient(tooth_extraction_treatment, patients_[3]);
+    sut_.addAwaitingPatient(tooth_extraction_treatment, patients_[0]);
+
+    const auto treatments_awaiting_before = sut_.treatmentsHavingQueue();
+    ASSERT_THAT(treatments_awaiting_before, UnorderedElementsAre(Treatment::DentalFilling, Treatment::ToothExtraction));
+
+    sut_.removeAwaitingPatient(filling_treatment, patients_[0]);
+    sut_.removeAwaitingPatient(filling_treatment, patients_[1]);
+    const auto treatments_after_removing_filling_patients = sut_.treatmentsHavingQueue();
+
+    sut_.removeAwaitingPatient(tooth_extraction_treatment, patients_[3]);
+    sut_.removeAwaitingPatient(tooth_extraction_treatment, patients_[0]);
+    const auto treatments_after_removing_extraction_patients = sut_.treatmentsHavingQueue();
+
+    EXPECT_THAT(treatments_after_removing_filling_patients, ElementsAre(Treatment::ToothExtraction));
+    EXPECT_TRUE(treatments_after_removing_extraction_patients.empty());
+}
+
+TEST_F(RemoveAwaitingPatientShould, RemovePatientFromBeginningOfSpecificDoctorQueue)
+{
+    sut_.addAwaitingPatient(doctors_[0], patients_[3]);
+    sut_.addAwaitingPatient(doctors_[0], patients_[2]);
+    sut_.addAwaitingPatient(doctors_[0], patients_[1]);
+    sut_.addAwaitingPatient(doctors_[0], patients_[0]);
+
+    const auto doctor_queued_patients_before = sut_.awaitingPatients(doctors_[0]);
+    ASSERT_THAT(doctor_queued_patients_before, ElementsAre(patients_[3], patients_[2], patients_[1], patients_[0]));
+
+    sut_.removeAwaitingPatient(doctors_[0], patients_[3]);
+    const auto doctor_queued_patients_after = sut_.awaitingPatients(doctors_[0]);
+
+    EXPECT_NE(doctor_queued_patients_before, doctor_queued_patients_after);
+    EXPECT_THAT(doctor_queued_patients_after, ElementsAre(patients_[2], patients_[1], patients_[0]));
+}
+
+TEST_F(RemoveAwaitingPatientShould, RemovePatientFromTheMiddleOfSpecificDoctorQueue)
+{
+    sut_.addAwaitingPatient(doctors_[0], patients_[3]);
+    sut_.addAwaitingPatient(doctors_[0], patients_[2]);
+    sut_.addAwaitingPatient(doctors_[0], patients_[1]);
+    sut_.addAwaitingPatient(doctors_[0], patients_[0]);
+
+    const auto doctor_queued_patients_before = sut_.awaitingPatients(doctors_[0]);
+    ASSERT_THAT(doctor_queued_patients_before, ElementsAre(patients_[3], patients_[2], patients_[1], patients_[0]));
+
+    sut_.removeAwaitingPatient(doctors_[0], patients_[2]);
+    sut_.removeAwaitingPatient(doctors_[0], patients_[1]);
+    const auto doctor_queued_patients_after = sut_.awaitingPatients(doctors_[0]);
+
+    EXPECT_NE(doctor_queued_patients_before, doctor_queued_patients_after);
+    EXPECT_THAT(doctor_queued_patients_after, ElementsAre(patients_[3], patients_[0]));
+}
+
+TEST_F(RemoveAwaitingPatientShould, RemovePatientFromTheEndOfSpecificDoctorQueue)
+{
+    sut_.addAwaitingPatient(doctors_[0], patients_[3]);
+    sut_.addAwaitingPatient(doctors_[0], patients_[2]);
+    sut_.addAwaitingPatient(doctors_[0], patients_[1]);
+    sut_.addAwaitingPatient(doctors_[0], patients_[0]);
+
+    const auto doctor_queued_patients_before = sut_.awaitingPatients(doctors_[0]);
+    ASSERT_THAT(doctor_queued_patients_before, ElementsAre(patients_[3], patients_[2], patients_[1], patients_[0]));
+
+    sut_.removeAwaitingPatient(doctors_[0], patients_[0]);
+    const auto doctor_queued_patients_after = sut_.awaitingPatients(doctors_[0]);
+
+    EXPECT_NE(doctor_queued_patients_before, doctor_queued_patients_after);
+    EXPECT_THAT(doctor_queued_patients_after, ElementsAre(patients_[3], patients_[2], patients_[1]));
+}
+
+TEST_F(RemoveAwaitingPatientShould, RemoveDoctorKeyIfLastPatientAwaitingRemoved)
+{
+    // first doctor queue
+    sut_.addAwaitingPatient(doctors_[0], patients_[3]);
+    sut_.addAwaitingPatient(doctors_[0], patients_[2]);
+    // second doctor queue
+    sut_.addAwaitingPatient(doctors_[1], patients_[2]);
+    sut_.addAwaitingPatient(doctors_[1], patients_[0]);
+
+    const auto doctors_awaiting_appointments_before = sut_.doctorsHavingQueue();
+    ASSERT_THAT(doctors_awaiting_appointments_before, UnorderedElementsAre(doctors_[0], doctors_[1]));
+
+    sut_.removeAwaitingPatient(doctors_[0], patients_[3]);
+    sut_.removeAwaitingPatient(doctors_[0], patients_[2]);
+    const auto doctors_awaiting_appointments_after_removing_first_doctor_patients = sut_.doctorsHavingQueue();
+
+    sut_.removeAwaitingPatient(doctors_[1], patients_[2]);
+    sut_.removeAwaitingPatient(doctors_[1], patients_[0]);
+    const auto doctors_awaiting_appointments_after_removing_second_doctor_patients = sut_.doctorsHavingQueue();
+
+    EXPECT_THAT(doctors_awaiting_appointments_after_removing_first_doctor_patients, ElementsAre(doctors_[1]));
+    EXPECT_TRUE(doctors_awaiting_appointments_after_removing_second_doctor_patients.empty());
+}
+
+class AwaitingPatientsShould : public ReserveQueueFixture
+{
+};
+
+TEST_F(AwaitingPatientsShould, ReturnEmptyQueueIfNoPatientForTreatmentQueued)
+{
+    sut_.addAwaitingPatient(Treatment::DentalSealants, patients_[0]);
+    sut_.addAwaitingPatient(Treatment::GumSurgery, patients_[1]);
+    ASSERT_FALSE(sut_.awaitingPatients(Treatment::DentalSealants).empty());
+    ASSERT_FALSE(sut_.awaitingPatients(Treatment::GumSurgery).empty());
+
+    EXPECT_TRUE(sut_.awaitingPatients(Treatment::ToothExtraction).empty());
+    EXPECT_TRUE(sut_.awaitingPatients(Treatment::OTHER).empty());
+}
+
+TEST_F(AwaitingPatientsShould, ReturnEmptyQueueIfNoPatientForDoctorQueued)
+{
+    sut_.addAwaitingPatient(doctors_[0], patients_[0]);
+    sut_.addAwaitingPatient(doctors_[1], patients_[1]);
+    ASSERT_FALSE(sut_.awaitingPatients(doctors_[0]).empty());
+    ASSERT_FALSE(sut_.awaitingPatients(doctors_[1]).empty());
+
+    EXPECT_TRUE(sut_.awaitingPatients(doctors_[2]).empty());
+}
+
+TEST_F(AwaitingPatientsShould, NotInsertTreatmentQueueKeyIfPatientForEmptyQueueRequested)
+{
+    const auto treatments_awaiting_before = sut_.treatmentsHavingQueue();
+
+    const auto patients_awaiting_treatment = sut_.awaitingPatients(Treatment::ToothExtraction);
+    const auto treatments_awaiting_after = sut_.treatmentsHavingQueue();
+
+    EXPECT_TRUE(patients_awaiting_treatment.empty());
+    EXPECT_TRUE(treatments_awaiting_before.empty());
+    EXPECT_TRUE(treatments_awaiting_after.empty());
+}
+
+class TreatmentsHavingQueueShould : public ReserveQueueFixture
+{
+};
+
+TEST_F(TreatmentsHavingQueueShould, ReturnEmptyTreatmentsListAfterReserveQueueInitialisation)
+{
+    const auto treatments_with_awaiting_patients{sut_.treatmentsHavingQueue()};
+    EXPECT_EQ(treatments_with_awaiting_patients.size(), 0);
+}
+
+TEST_F(TreatmentsHavingQueueShould, ReturnListOfAllTreatmentsWithAtLeastOnePatientAwaiting)
+{
+    Treatment filling_treatment{Treatment::DentalFilling};
+    sut_.addAwaitingPatient(filling_treatment, patients_[0]);
+    sut_.addAwaitingPatient(filling_treatment, patients_[1]);
+
+    Treatment tooth_extraction_treatment{Treatment::ToothExtraction};
+    sut_.addAwaitingPatient(tooth_extraction_treatment, patients_[3]);
+    sut_.addAwaitingPatient(tooth_extraction_treatment, patients_[0]);
+
+    Treatment gum_surgery_treatment{Treatment::GumSurgery};
+    sut_.addAwaitingPatient(gum_surgery_treatment, patients_[2]);
+
+    EXPECT_THAT(sut_.treatmentsHavingQueue(),
+                UnorderedElementsAre(filling_treatment, tooth_extraction_treatment, gum_surgery_treatment));
+}
+
+class DoctorsHavingQueueShould : public ReserveQueueFixture
+{
+};
+
+TEST_F(DoctorsHavingQueueShould, ReturnEmptyDoctorListAfterReserveQueueInitialisation)
+{
+    const auto doctors_awaited_for_appointment{sut_.doctorsHavingQueue()};
+    EXPECT_EQ(doctors_awaited_for_appointment.size(), 0);
+}
+
+TEST_F(DoctorsHavingQueueShould, ReturnListOfAllDoctorsWithAtLeastOnePatientAwaiting)
+{
+    // first doctor queue
+    sut_.addAwaitingPatient(doctors_[0], patients_[3]);
+    sut_.addAwaitingPatient(doctors_[0], patients_[2]);
+    sut_.addAwaitingPatient(doctors_[0], patients_[1]);
+    sut_.addAwaitingPatient(doctors_[0], patients_[0]);
+    // second doctor queue
+    sut_.addAwaitingPatient(doctors_[1], patients_[2]);
+
+    EXPECT_THAT(sut_.doctorsHavingQueue(), UnorderedElementsAre(doctors_[0], doctors_[1]));
+}
+
+} // anonymous namespace

--- a/src/tests/ut/reserve_queue/reserve_queue_test.cpp
+++ b/src/tests/ut/reserve_queue/reserve_queue_test.cpp
@@ -7,351 +7,326 @@ namespace
 using ::testing::ElementsAre;
 using ::testing::UnorderedElementsAre;
 
-class AddAwaitingPatientShould : public ReserveQueueFixture
+class addPatientToQueueShould : public ReserveQueueFixture
 {
 };
 
-TEST_F(AddAwaitingPatientShould, EnqueuePatientsForTreatmentInCorrectOrder)
+TEST_F(addPatientToQueueShould, EnqueuePatientsForTreatmentInCorrectOrder)
 {
     Treatment filling_treatment{Treatment::DentalFilling};
-    sut_.addAwaitingPatient(filling_treatment, patients_[0]);
-    sut_.addAwaitingPatient(filling_treatment, patients_[1]);
-    sut_.addAwaitingPatient(filling_treatment, patients_[2]);
-    sut_.addAwaitingPatient(filling_treatment, patients_[3]);
+    sut_.addPatientToQueue(filling_treatment, patients_[0]);
+    sut_.addPatientToQueue(filling_treatment, patients_[3]);
 
     Treatment tooth_extraction_treatment{Treatment::ToothExtraction};
-    sut_.addAwaitingPatient(tooth_extraction_treatment, patients_[3]);
-    sut_.addAwaitingPatient(tooth_extraction_treatment, patients_[0]);
-    sut_.addAwaitingPatient(tooth_extraction_treatment, patients_[1]);
+    sut_.addPatientToQueue(tooth_extraction_treatment, patients_[3]);
+    sut_.addPatientToQueue(tooth_extraction_treatment, patients_[1]);
 
-    const auto filling_treatment_queued_patients = sut_.awaitingPatients(filling_treatment);
-    const auto tooth_extraction_queed_patients = sut_.awaitingPatients(tooth_extraction_treatment);
+    const auto filling_treatment_queued_patients = sut_.getQueuedPatients(filling_treatment);
+    const auto tooth_extraction_queed_patients = sut_.getQueuedPatients(tooth_extraction_treatment);
 
-    EXPECT_THAT(filling_treatment_queued_patients, ElementsAre(patients_[0], patients_[1], patients_[2], patients_[3]));
-    EXPECT_THAT(tooth_extraction_queed_patients, ElementsAre(patients_[3], patients_[0], patients_[1]));
+    EXPECT_THAT(filling_treatment_queued_patients, ElementsAre(patients_[0], patients_[3]));
+    EXPECT_THAT(tooth_extraction_queed_patients, ElementsAre(patients_[3], patients_[1]));
 }
 
-TEST_F(AddAwaitingPatientShould, NotEnQueuePatientsIfAlreadyEnqueuedForSpecificTreatment)
+TEST_F(addPatientToQueueShould, NotEnQueuePatientsIfAlreadyEnqueuedForSpecificTreatment)
 {
     Treatment tooth_extraction_treatment{Treatment::ToothExtraction};
-    sut_.addAwaitingPatient(tooth_extraction_treatment, patients_[3]);
-    sut_.addAwaitingPatient(tooth_extraction_treatment, patients_[0]);
+    sut_.addPatientToQueue(tooth_extraction_treatment, patients_[3]);
+    sut_.addPatientToQueue(tooth_extraction_treatment, patients_[0]);
 
-    sut_.addAwaitingPatient(tooth_extraction_treatment, patients_[3]);
-    sut_.addAwaitingPatient(tooth_extraction_treatment, patients_[0]);
+    sut_.addPatientToQueue(tooth_extraction_treatment, patients_[3]);
+    sut_.addPatientToQueue(tooth_extraction_treatment, patients_[0]);
 
-    const auto tooth_extraction_queed_patients = sut_.awaitingPatients(tooth_extraction_treatment);
+    const auto tooth_extraction_queed_patients = sut_.getQueuedPatients(tooth_extraction_treatment);
 
     EXPECT_THAT(tooth_extraction_queed_patients, ElementsAre(patients_[3], patients_[0]));
 }
 
-TEST_F(AddAwaitingPatientShould, EnqueuePatientsForDoctorInCorrectOrder)
+TEST_F(addPatientToQueueShould, EnqueuePatientsForDoctorInCorrectOrder)
 {
-    // first doctor queue
-    sut_.addAwaitingPatient(doctors_[0], patients_[3]);
-    sut_.addAwaitingPatient(doctors_[0], patients_[2]);
-    sut_.addAwaitingPatient(doctors_[0], patients_[1]);
-    sut_.addAwaitingPatient(doctors_[0], patients_[0]);
-    // second doctor queue
-    sut_.addAwaitingPatient(doctors_[1], patients_[2]);
-    sut_.addAwaitingPatient(doctors_[1], patients_[0]);
-    // third doctor queue
-    sut_.addAwaitingPatient(doctors_[2], patients_[1]);
-    sut_.addAwaitingPatient(doctors_[2], patients_[0]);
-    sut_.addAwaitingPatient(doctors_[2], patients_[3]);
-    sut_.addAwaitingPatient(doctors_[2], patients_[2]);
+    sut_.addPatientToQueue(doctors_[0], patients_[2]);
+    sut_.addPatientToQueue(doctors_[0], patients_[1]);
 
-    const auto first_doctor_queued_patients = sut_.awaitingPatients(doctors_[0]);
-    const auto second_doctor_queued_patients = sut_.awaitingPatients(doctors_[1]);
-    const auto third_doctor_queued_patients = sut_.awaitingPatients(doctors_[2]);
+    sut_.addPatientToQueue(doctors_[1], patients_[2]);
+    sut_.addPatientToQueue(doctors_[1], patients_[0]);
 
-    EXPECT_THAT(first_doctor_queued_patients, ElementsAre(patients_[3], patients_[2], patients_[1], patients_[0]));
+    sut_.addPatientToQueue(doctors_[2], patients_[1]);
+    sut_.addPatientToQueue(doctors_[2], patients_[3]);
+
+    const auto first_doctor_queued_patients = sut_.getQueuedPatients(doctors_[0]);
+    const auto second_doctor_queued_patients = sut_.getQueuedPatients(doctors_[1]);
+    const auto third_doctor_queued_patients = sut_.getQueuedPatients(doctors_[2]);
+
+    EXPECT_THAT(first_doctor_queued_patients, ElementsAre(patients_[2], patients_[1]));
     EXPECT_THAT(second_doctor_queued_patients, ElementsAre(patients_[2], patients_[0]));
-    EXPECT_THAT(third_doctor_queued_patients, ElementsAre(patients_[1], patients_[0], patients_[3], patients_[2]));
+    EXPECT_THAT(third_doctor_queued_patients, ElementsAre(patients_[1], patients_[3]));
 }
 
-TEST_F(AddAwaitingPatientShould, NotEnQueuePatientsIfAlreadyEnqueuedForSpecificDoctor)
+TEST_F(addPatientToQueueShould, NotEnQueuePatientsIfAlreadyEnqueuedForSpecificDoctor)
 {
-    sut_.addAwaitingPatient(doctors_[1], patients_[2]);
-    sut_.addAwaitingPatient(doctors_[1], patients_[1]);
-    sut_.addAwaitingPatient(doctors_[1], patients_[0]);
-    sut_.addAwaitingPatient(doctors_[1], patients_[2]);
-    sut_.addAwaitingPatient(doctors_[1], patients_[0]);
+    sut_.addPatientToQueue(doctors_[1], patients_[2]);
+    sut_.addPatientToQueue(doctors_[1], patients_[1]);
+    sut_.addPatientToQueue(doctors_[1], patients_[0]);
+    sut_.addPatientToQueue(doctors_[1], patients_[2]);
+    sut_.addPatientToQueue(doctors_[1], patients_[0]);
 
-    const auto doctor_queued_patients = sut_.awaitingPatients(doctors_[1]);
+    const auto doctor_queued_patients = sut_.getQueuedPatients(doctors_[1]);
 
     EXPECT_THAT(doctor_queued_patients, ElementsAre(patients_[2], patients_[1], patients_[0]));
 }
 
-class RemoveAwaitingPatientShould : public ReserveQueueFixture
+class removePatientFromQueueShould : public ReserveQueueFixture
 {
 };
 
-TEST_F(RemoveAwaitingPatientShould, NotChangeTreatmentQueueIfPatientNotPresentInQueue)
+TEST_F(removePatientFromQueueShould, NotChangeTreatmentQueueIfPatientNotPresentInQueue)
 {
     Treatment filling_treatment{Treatment::DentalFilling};
-    sut_.addAwaitingPatient(filling_treatment, patients_[0]);
-    sut_.addAwaitingPatient(filling_treatment, patients_[1]);
-    sut_.addAwaitingPatient(filling_treatment, patients_[2]);
+    sut_.addPatientToQueue(filling_treatment, patients_[1]);
+    sut_.addPatientToQueue(filling_treatment, patients_[2]);
 
     Treatment tooth_extraction_treatment{Treatment::ToothExtraction};
-    sut_.addAwaitingPatient(tooth_extraction_treatment, patients_[3]);
-    sut_.addAwaitingPatient(tooth_extraction_treatment, patients_[0]);
+    sut_.addPatientToQueue(tooth_extraction_treatment, patients_[3]);
+    sut_.addPatientToQueue(tooth_extraction_treatment, patients_[0]);
 
-    const auto filling_treatment_patients_before = sut_.awaitingPatients(filling_treatment);
-    const auto tooth_extraction_patients_before = sut_.awaitingPatients(tooth_extraction_treatment);
+    const auto filling_treatment_patients_before = sut_.getQueuedPatients(filling_treatment);
+    const auto tooth_extraction_patients_before = sut_.getQueuedPatients(tooth_extraction_treatment);
 
-    ASSERT_THAT(filling_treatment_patients_before, ElementsAre(patients_[0], patients_[1], patients_[2]));
+    ASSERT_THAT(filling_treatment_patients_before, ElementsAre(patients_[1], patients_[2]));
     ASSERT_THAT(tooth_extraction_patients_before, ElementsAre(patients_[3], patients_[0]));
 
-    sut_.removeAwaitingPatient(filling_treatment, patients_[3]);
-    sut_.removeAwaitingPatient(tooth_extraction_treatment, patients_[1]);
+    sut_.removePatientFromQueue(filling_treatment, patients_[3]);
+    sut_.removePatientFromQueue(tooth_extraction_treatment, patients_[1]);
 
-    const auto filling_treatment_patients_after = sut_.awaitingPatients(filling_treatment);
-    const auto tooth_extraction_patients_after = sut_.awaitingPatients(tooth_extraction_treatment);
+    const auto filling_treatment_patients_after = sut_.getQueuedPatients(filling_treatment);
+    const auto tooth_extraction_patients_after = sut_.getQueuedPatients(tooth_extraction_treatment);
 
     EXPECT_EQ(filling_treatment_patients_before, filling_treatment_patients_after);
     EXPECT_EQ(tooth_extraction_patients_before, tooth_extraction_patients_after);
 }
 
-TEST_F(RemoveAwaitingPatientShould, NotChangeDoctorQueueIfPatientNotPresentInQueue)
+TEST_F(removePatientFromQueueShould, NotChangeDoctorQueueIfPatientNotPresentInQueue)
 {
-    // first doctor queue
-    sut_.addAwaitingPatient(doctors_[0], patients_[2]);
-    sut_.addAwaitingPatient(doctors_[0], patients_[1]);
-    // second doctor queue
-    sut_.addAwaitingPatient(doctors_[1], patients_[3]);
-    sut_.addAwaitingPatient(doctors_[1], patients_[0]);
+    sut_.addPatientToQueue(doctors_[0], patients_[2]);
+    sut_.addPatientToQueue(doctors_[0], patients_[1]);
 
-    const auto first_doctor_patients_before = sut_.awaitingPatients(doctors_[0]);
-    const auto second_doctor_patients_before = sut_.awaitingPatients(doctors_[1]);
+    sut_.addPatientToQueue(doctors_[1], patients_[3]);
+    sut_.addPatientToQueue(doctors_[1], patients_[0]);
+
+    const auto first_doctor_patients_before = sut_.getQueuedPatients(doctors_[0]);
+    const auto second_doctor_patients_before = sut_.getQueuedPatients(doctors_[1]);
 
     ASSERT_THAT(first_doctor_patients_before, ElementsAre(patients_[2], patients_[1]));
     ASSERT_THAT(second_doctor_patients_before, ElementsAre(patients_[3], patients_[0]));
 
-    sut_.removeAwaitingPatient(doctors_[0], patients_[3]);
-    sut_.removeAwaitingPatient(doctors_[1], patients_[1]);
+    sut_.removePatientFromQueue(doctors_[0], patients_[3]);
+    sut_.removePatientFromQueue(doctors_[1], patients_[1]);
 
-    const auto first_doctor_patients_after = sut_.awaitingPatients(doctors_[0]);
-    const auto second_doctor_patients_after = sut_.awaitingPatients(doctors_[1]);
+    const auto first_doctor_patients_after = sut_.getQueuedPatients(doctors_[0]);
+    const auto second_doctor_patients_after = sut_.getQueuedPatients(doctors_[1]);
 
     EXPECT_EQ(first_doctor_patients_before, first_doctor_patients_after);
     EXPECT_EQ(second_doctor_patients_before, second_doctor_patients_after);
 }
 
-TEST_F(RemoveAwaitingPatientShould, NotAddTreatmentKeyIfRemovalRequestedFromEmptyList)
+TEST_F(removePatientFromQueueShould, NotAddTreatmentKeyIfRemovalRequestedFromEmptyList)
 {
     const auto treatments_awaiting_before = sut_.treatmentsHavingQueue();
     ASSERT_TRUE(treatments_awaiting_before.empty());
 
-    sut_.removeAwaitingPatient(Treatment::DentalFilling, patients_[0]);
-    sut_.removeAwaitingPatient(Treatment::ToothExtraction, patients_[1]);
-    const auto treatments_awaiting_after_removal_attempts = sut_.treatmentsHavingQueue();
+    sut_.removePatientFromQueue(Treatment::DentalFilling, patients_[0]);
+    sut_.removePatientFromQueue(Treatment::ToothExtraction, patients_[1]);
 
-    EXPECT_TRUE(treatments_awaiting_after_removal_attempts.empty());
+    expectTreatmentsHavingQueueEmpty();
 }
 
-TEST_F(RemoveAwaitingPatientShould, NotAddDoctorKeyIfRemovalRequestedFromEmptyList)
+TEST_F(removePatientFromQueueShould, NotAddDoctorKeyIfRemovalRequestedFromEmptyList)
 {
     const auto doctors_with_patients_awaiting_appointments_before = sut_.doctorsHavingQueue();
     ASSERT_TRUE(doctors_with_patients_awaiting_appointments_before.empty());
 
-    sut_.removeAwaitingPatient(doctors_[0], patients_[0]);
-    sut_.removeAwaitingPatient(doctors_[1], patients_[1]);
-    const auto doctors_with_patients_awaiting_appointments_after_removal_attempts = sut_.doctorsHavingQueue();
+    sut_.removePatientFromQueue(doctors_[0], patients_[0]);
+    sut_.removePatientFromQueue(doctors_[1], patients_[1]);
 
-    EXPECT_TRUE(doctors_with_patients_awaiting_appointments_after_removal_attempts.empty());
+    expectDoctorsHavingQueueEmpty();
 }
 
-TEST_F(RemoveAwaitingPatientShould, RemovePatientFromBeginningOfSpecificTreatmentQueue)
+TEST_F(removePatientFromQueueShould, RemovePatientFromBeginningOfSpecificTreatmentQueue)
 {
     Treatment filling_treatment{Treatment::DentalFilling};
-    sut_.addAwaitingPatient(filling_treatment, patients_[0]);
-    sut_.addAwaitingPatient(filling_treatment, patients_[1]);
-    sut_.addAwaitingPatient(filling_treatment, patients_[2]);
-    sut_.addAwaitingPatient(filling_treatment, patients_[3]);
+    sut_.addPatientToQueue(filling_treatment, patients_[0]);
+    sut_.addPatientToQueue(filling_treatment, patients_[2]);
 
-    const auto filling_treatment_patients_before = sut_.awaitingPatients(filling_treatment);
+    const auto filling_treatment_patients_before = sut_.getQueuedPatients(filling_treatment);
 
-    ASSERT_THAT(filling_treatment_patients_before, ElementsAre(patients_[0], patients_[1], patients_[2], patients_[3]));
+    ASSERT_THAT(filling_treatment_patients_before, ElementsAre(patients_[0], patients_[2]));
 
-    sut_.removeAwaitingPatient(filling_treatment, patients_[0]);
-    const auto filling_treatment_patients_after = sut_.awaitingPatients(filling_treatment);
+    sut_.removePatientFromQueue(filling_treatment, patients_[0]);
+    const auto filling_treatment_patients_after = sut_.getQueuedPatients(filling_treatment);
 
     EXPECT_NE(filling_treatment_patients_before, filling_treatment_patients_after);
-    EXPECT_THAT(filling_treatment_patients_after, ElementsAre(patients_[1], patients_[2], patients_[3]));
+    EXPECT_THAT(filling_treatment_patients_after, ElementsAre(patients_[2]));
 }
 
-TEST_F(RemoveAwaitingPatientShould, RemovePatientFromTheMiddleOfSpecificTreatmentQueue)
+TEST_F(removePatientFromQueueShould, RemovePatientFromTheMiddleOfSpecificTreatmentQueue)
 {
     Treatment filling_treatment{Treatment::DentalFilling};
-    sut_.addAwaitingPatient(filling_treatment, patients_[0]);
-    sut_.addAwaitingPatient(filling_treatment, patients_[1]);
-    sut_.addAwaitingPatient(filling_treatment, patients_[2]);
-    sut_.addAwaitingPatient(filling_treatment, patients_[3]);
+    sut_.addPatientToQueue(filling_treatment, patients_[0]);
+    sut_.addPatientToQueue(filling_treatment, patients_[2]);
+    sut_.addPatientToQueue(filling_treatment, patients_[3]);
 
-    const auto filling_treatment_patients_before = sut_.awaitingPatients(filling_treatment);
+    const auto filling_treatment_patients_before = sut_.getQueuedPatients(filling_treatment);
 
-    ASSERT_THAT(filling_treatment_patients_before, ElementsAre(patients_[0], patients_[1], patients_[2], patients_[3]));
+    ASSERT_THAT(filling_treatment_patients_before, ElementsAre(patients_[0], patients_[2], patients_[3]));
 
-    sut_.removeAwaitingPatient(filling_treatment, patients_[1]);
-    sut_.removeAwaitingPatient(filling_treatment, patients_[2]);
-    const auto filling_treatment_patients_after = sut_.awaitingPatients(filling_treatment);
+    sut_.removePatientFromQueue(filling_treatment, patients_[2]);
+    const auto filling_treatment_patients_after = sut_.getQueuedPatients(filling_treatment);
 
     EXPECT_NE(filling_treatment_patients_before, filling_treatment_patients_after);
     EXPECT_THAT(filling_treatment_patients_after, ElementsAre(patients_[0], patients_[3]));
 }
 
-TEST_F(RemoveAwaitingPatientShould, RemovePatientFromTheEndOfSpecificTreatmentQueue)
+TEST_F(removePatientFromQueueShould, RemovePatientFromTheEndOfSpecificTreatmentQueue)
 {
     Treatment filling_treatment{Treatment::DentalFilling};
-    sut_.addAwaitingPatient(filling_treatment, patients_[0]);
-    sut_.addAwaitingPatient(filling_treatment, patients_[1]);
-    sut_.addAwaitingPatient(filling_treatment, patients_[2]);
-    sut_.addAwaitingPatient(filling_treatment, patients_[3]);
+    sut_.addPatientToQueue(filling_treatment, patients_[0]);
+    sut_.addPatientToQueue(filling_treatment, patients_[2]);
 
-    const auto filling_treatment_patients_before = sut_.awaitingPatients(filling_treatment);
+    const auto filling_treatment_patients_before = sut_.getQueuedPatients(filling_treatment);
 
-    ASSERT_THAT(filling_treatment_patients_before, ElementsAre(patients_[0], patients_[1], patients_[2], patients_[3]));
+    ASSERT_THAT(filling_treatment_patients_before, ElementsAre(patients_[0], patients_[2]));
 
-    sut_.removeAwaitingPatient(filling_treatment, patients_[3]);
-    const auto filling_treatment_patients_after = sut_.awaitingPatients(filling_treatment);
+    sut_.removePatientFromQueue(filling_treatment, patients_[2]);
+    const auto filling_treatment_patients_after = sut_.getQueuedPatients(filling_treatment);
 
     EXPECT_NE(filling_treatment_patients_before, filling_treatment_patients_after);
-    EXPECT_THAT(filling_treatment_patients_after, ElementsAre(patients_[0], patients_[1], patients_[2]));
+    EXPECT_THAT(filling_treatment_patients_after, ElementsAre(patients_[0]));
 }
 
-TEST_F(RemoveAwaitingPatientShould, RemoveTreatmentKeyIfLastPatientAwaitingRemoved)
+TEST_F(removePatientFromQueueShould, RemoveTreatmentKeyIfLastPatientAwaitingRemoved)
 {
     Treatment filling_treatment{Treatment::DentalFilling};
-    sut_.addAwaitingPatient(filling_treatment, patients_[0]);
-    sut_.addAwaitingPatient(filling_treatment, patients_[1]);
+    sut_.addPatientToQueue(filling_treatment, patients_[0]);
+    sut_.addPatientToQueue(filling_treatment, patients_[1]);
 
     Treatment tooth_extraction_treatment{Treatment::ToothExtraction};
-    sut_.addAwaitingPatient(tooth_extraction_treatment, patients_[3]);
-    sut_.addAwaitingPatient(tooth_extraction_treatment, patients_[0]);
+    sut_.addPatientToQueue(tooth_extraction_treatment, patients_[3]);
+    sut_.addPatientToQueue(tooth_extraction_treatment, patients_[0]);
 
     const auto treatments_awaiting_before = sut_.treatmentsHavingQueue();
     ASSERT_THAT(treatments_awaiting_before, UnorderedElementsAre(Treatment::DentalFilling, Treatment::ToothExtraction));
 
-    sut_.removeAwaitingPatient(filling_treatment, patients_[0]);
-    sut_.removeAwaitingPatient(filling_treatment, patients_[1]);
+    sut_.removePatientFromQueue(filling_treatment, patients_[0]);
+    sut_.removePatientFromQueue(filling_treatment, patients_[1]);
     const auto treatments_after_removing_filling_patients = sut_.treatmentsHavingQueue();
 
-    sut_.removeAwaitingPatient(tooth_extraction_treatment, patients_[3]);
-    sut_.removeAwaitingPatient(tooth_extraction_treatment, patients_[0]);
+    sut_.removePatientFromQueue(tooth_extraction_treatment, patients_[3]);
+    sut_.removePatientFromQueue(tooth_extraction_treatment, patients_[0]);
     const auto treatments_after_removing_extraction_patients = sut_.treatmentsHavingQueue();
 
     EXPECT_THAT(treatments_after_removing_filling_patients, ElementsAre(Treatment::ToothExtraction));
     EXPECT_TRUE(treatments_after_removing_extraction_patients.empty());
 }
 
-TEST_F(RemoveAwaitingPatientShould, RemovePatientFromBeginningOfSpecificDoctorQueue)
+TEST_F(removePatientFromQueueShould, RemovePatientFromBeginningOfSpecificDoctorQueue)
 {
-    sut_.addAwaitingPatient(doctors_[0], patients_[3]);
-    sut_.addAwaitingPatient(doctors_[0], patients_[2]);
-    sut_.addAwaitingPatient(doctors_[0], patients_[1]);
-    sut_.addAwaitingPatient(doctors_[0], patients_[0]);
+    sut_.addPatientToQueue(doctors_[0], patients_[3]);
+    sut_.addPatientToQueue(doctors_[0], patients_[2]);
 
-    const auto doctor_queued_patients_before = sut_.awaitingPatients(doctors_[0]);
-    ASSERT_THAT(doctor_queued_patients_before, ElementsAre(patients_[3], patients_[2], patients_[1], patients_[0]));
+    const auto doctor_queued_patients_before = sut_.getQueuedPatients(doctors_[0]);
+    ASSERT_THAT(doctor_queued_patients_before, ElementsAre(patients_[3], patients_[2]));
 
-    sut_.removeAwaitingPatient(doctors_[0], patients_[3]);
-    const auto doctor_queued_patients_after = sut_.awaitingPatients(doctors_[0]);
+    sut_.removePatientFromQueue(doctors_[0], patients_[3]);
+    const auto doctor_queued_patients_after = sut_.getQueuedPatients(doctors_[0]);
 
     EXPECT_NE(doctor_queued_patients_before, doctor_queued_patients_after);
-    EXPECT_THAT(doctor_queued_patients_after, ElementsAre(patients_[2], patients_[1], patients_[0]));
+    EXPECT_THAT(doctor_queued_patients_after, ElementsAre(patients_[2]));
 }
 
-TEST_F(RemoveAwaitingPatientShould, RemovePatientFromTheMiddleOfSpecificDoctorQueue)
+TEST_F(removePatientFromQueueShould, RemovePatientFromTheMiddleOfSpecificDoctorQueue)
 {
-    sut_.addAwaitingPatient(doctors_[0], patients_[3]);
-    sut_.addAwaitingPatient(doctors_[0], patients_[2]);
-    sut_.addAwaitingPatient(doctors_[0], patients_[1]);
-    sut_.addAwaitingPatient(doctors_[0], patients_[0]);
+    sut_.addPatientToQueue(doctors_[0], patients_[3]);
+    sut_.addPatientToQueue(doctors_[0], patients_[2]);
+    sut_.addPatientToQueue(doctors_[0], patients_[1]);
 
-    const auto doctor_queued_patients_before = sut_.awaitingPatients(doctors_[0]);
-    ASSERT_THAT(doctor_queued_patients_before, ElementsAre(patients_[3], patients_[2], patients_[1], patients_[0]));
+    const auto doctor_queued_patients_before = sut_.getQueuedPatients(doctors_[0]);
+    ASSERT_THAT(doctor_queued_patients_before, ElementsAre(patients_[3], patients_[2], patients_[1]));
 
-    sut_.removeAwaitingPatient(doctors_[0], patients_[2]);
-    sut_.removeAwaitingPatient(doctors_[0], patients_[1]);
-    const auto doctor_queued_patients_after = sut_.awaitingPatients(doctors_[0]);
+    sut_.removePatientFromQueue(doctors_[0], patients_[2]);
+    const auto doctor_queued_patients_after = sut_.getQueuedPatients(doctors_[0]);
 
     EXPECT_NE(doctor_queued_patients_before, doctor_queued_patients_after);
-    EXPECT_THAT(doctor_queued_patients_after, ElementsAre(patients_[3], patients_[0]));
+    EXPECT_THAT(doctor_queued_patients_after, ElementsAre(patients_[3], patients_[1]));
 }
 
-TEST_F(RemoveAwaitingPatientShould, RemovePatientFromTheEndOfSpecificDoctorQueue)
+TEST_F(removePatientFromQueueShould, RemovePatientFromTheEndOfSpecificDoctorQueue)
 {
-    sut_.addAwaitingPatient(doctors_[0], patients_[3]);
-    sut_.addAwaitingPatient(doctors_[0], patients_[2]);
-    sut_.addAwaitingPatient(doctors_[0], patients_[1]);
-    sut_.addAwaitingPatient(doctors_[0], patients_[0]);
+    sut_.addPatientToQueue(doctors_[0], patients_[3]);
+    sut_.addPatientToQueue(doctors_[0], patients_[2]);
 
-    const auto doctor_queued_patients_before = sut_.awaitingPatients(doctors_[0]);
-    ASSERT_THAT(doctor_queued_patients_before, ElementsAre(patients_[3], patients_[2], patients_[1], patients_[0]));
+    const auto doctor_queued_patients_before = sut_.getQueuedPatients(doctors_[0]);
+    ASSERT_THAT(doctor_queued_patients_before, ElementsAre(patients_[3], patients_[2]));
 
-    sut_.removeAwaitingPatient(doctors_[0], patients_[0]);
-    const auto doctor_queued_patients_after = sut_.awaitingPatients(doctors_[0]);
+    sut_.removePatientFromQueue(doctors_[0], patients_[2]);
+    const auto doctor_queued_patients_after = sut_.getQueuedPatients(doctors_[0]);
 
     EXPECT_NE(doctor_queued_patients_before, doctor_queued_patients_after);
-    EXPECT_THAT(doctor_queued_patients_after, ElementsAre(patients_[3], patients_[2], patients_[1]));
+    EXPECT_THAT(doctor_queued_patients_after, ElementsAre(patients_[3]));
 }
 
-TEST_F(RemoveAwaitingPatientShould, RemoveDoctorKeyIfLastPatientAwaitingRemoved)
+TEST_F(removePatientFromQueueShould, RemoveDoctorKeyIfLastPatientAwaitingRemoved)
 {
-    // first doctor queue
-    sut_.addAwaitingPatient(doctors_[0], patients_[3]);
-    sut_.addAwaitingPatient(doctors_[0], patients_[2]);
-    // second doctor queue
-    sut_.addAwaitingPatient(doctors_[1], patients_[2]);
-    sut_.addAwaitingPatient(doctors_[1], patients_[0]);
+    sut_.addPatientToQueue(doctors_[0], patients_[3]);
+    sut_.addPatientToQueue(doctors_[0], patients_[2]);
+
+    sut_.addPatientToQueue(doctors_[1], patients_[2]);
+    sut_.addPatientToQueue(doctors_[1], patients_[0]);
 
     const auto doctors_awaiting_appointments_before = sut_.doctorsHavingQueue();
     ASSERT_THAT(doctors_awaiting_appointments_before, UnorderedElementsAre(doctors_[0], doctors_[1]));
 
-    sut_.removeAwaitingPatient(doctors_[0], patients_[3]);
-    sut_.removeAwaitingPatient(doctors_[0], patients_[2]);
+    sut_.removePatientFromQueue(doctors_[0], patients_[3]);
+    sut_.removePatientFromQueue(doctors_[0], patients_[2]);
     const auto doctors_awaiting_appointments_after_removing_first_doctor_patients = sut_.doctorsHavingQueue();
 
-    sut_.removeAwaitingPatient(doctors_[1], patients_[2]);
-    sut_.removeAwaitingPatient(doctors_[1], patients_[0]);
+    sut_.removePatientFromQueue(doctors_[1], patients_[2]);
+    sut_.removePatientFromQueue(doctors_[1], patients_[0]);
     const auto doctors_awaiting_appointments_after_removing_second_doctor_patients = sut_.doctorsHavingQueue();
 
     EXPECT_THAT(doctors_awaiting_appointments_after_removing_first_doctor_patients, ElementsAre(doctors_[1]));
     EXPECT_TRUE(doctors_awaiting_appointments_after_removing_second_doctor_patients.empty());
 }
 
-class AwaitingPatientsShould : public ReserveQueueFixture
+class getQueuedPatientsShould : public ReserveQueueFixture
 {
 };
 
-TEST_F(AwaitingPatientsShould, ReturnEmptyQueueIfNoPatientForTreatmentQueued)
+TEST_F(getQueuedPatientsShould, ReturnEmptyQueueIfNoPatientForTreatmentQueued)
 {
-    sut_.addAwaitingPatient(Treatment::DentalSealants, patients_[0]);
-    sut_.addAwaitingPatient(Treatment::GumSurgery, patients_[1]);
-    ASSERT_FALSE(sut_.awaitingPatients(Treatment::DentalSealants).empty());
-    ASSERT_FALSE(sut_.awaitingPatients(Treatment::GumSurgery).empty());
+    sut_.addPatientToQueue(Treatment::DentalSealants, patients_[0]);
+    sut_.addPatientToQueue(Treatment::GumSurgery, patients_[1]);
+    ASSERT_FALSE(sut_.getQueuedPatients(Treatment::DentalSealants).empty());
+    ASSERT_FALSE(sut_.getQueuedPatients(Treatment::GumSurgery).empty());
 
-    EXPECT_TRUE(sut_.awaitingPatients(Treatment::ToothExtraction).empty());
-    EXPECT_TRUE(sut_.awaitingPatients(Treatment::OTHER).empty());
+    EXPECT_TRUE(sut_.getQueuedPatients(Treatment::ToothExtraction).empty());
+    EXPECT_TRUE(sut_.getQueuedPatients(Treatment::OTHER).empty());
 }
 
-TEST_F(AwaitingPatientsShould, ReturnEmptyQueueIfNoPatientForDoctorQueued)
+TEST_F(getQueuedPatientsShould, ReturnEmptyQueueIfNoPatientForDoctorQueued)
 {
-    sut_.addAwaitingPatient(doctors_[0], patients_[0]);
-    sut_.addAwaitingPatient(doctors_[1], patients_[1]);
-    ASSERT_FALSE(sut_.awaitingPatients(doctors_[0]).empty());
-    ASSERT_FALSE(sut_.awaitingPatients(doctors_[1]).empty());
+    sut_.addPatientToQueue(doctors_[0], patients_[0]);
+    sut_.addPatientToQueue(doctors_[1], patients_[1]);
+    ASSERT_FALSE(sut_.getQueuedPatients(doctors_[0]).empty());
+    ASSERT_FALSE(sut_.getQueuedPatients(doctors_[1]).empty());
 
-    EXPECT_TRUE(sut_.awaitingPatients(doctors_[2]).empty());
+    EXPECT_TRUE(sut_.getQueuedPatients(doctors_[2]).empty());
 }
 
-TEST_F(AwaitingPatientsShould, NotInsertTreatmentQueueKeyIfPatientForEmptyQueueRequested)
+TEST_F(getQueuedPatientsShould, NotInsertTreatmentQueueKeyIfPatientForEmptyQueueRequested)
 {
     const auto treatments_awaiting_before = sut_.treatmentsHavingQueue();
 
-    const auto patients_awaiting_treatment = sut_.awaitingPatients(Treatment::ToothExtraction);
+    const auto patients_awaiting_treatment = sut_.getQueuedPatients(Treatment::ToothExtraction);
     const auto treatments_awaiting_after = sut_.treatmentsHavingQueue();
 
     EXPECT_TRUE(patients_awaiting_treatment.empty());
@@ -372,15 +347,15 @@ TEST_F(TreatmentsHavingQueueShould, ReturnEmptyTreatmentsListAfterReserveQueueIn
 TEST_F(TreatmentsHavingQueueShould, ReturnListOfAllTreatmentsWithAtLeastOnePatientAwaiting)
 {
     Treatment filling_treatment{Treatment::DentalFilling};
-    sut_.addAwaitingPatient(filling_treatment, patients_[0]);
-    sut_.addAwaitingPatient(filling_treatment, patients_[1]);
+    sut_.addPatientToQueue(filling_treatment, patients_[0]);
+    sut_.addPatientToQueue(filling_treatment, patients_[1]);
 
     Treatment tooth_extraction_treatment{Treatment::ToothExtraction};
-    sut_.addAwaitingPatient(tooth_extraction_treatment, patients_[3]);
-    sut_.addAwaitingPatient(tooth_extraction_treatment, patients_[0]);
+    sut_.addPatientToQueue(tooth_extraction_treatment, patients_[3]);
+    sut_.addPatientToQueue(tooth_extraction_treatment, patients_[0]);
 
     Treatment gum_surgery_treatment{Treatment::GumSurgery};
-    sut_.addAwaitingPatient(gum_surgery_treatment, patients_[2]);
+    sut_.addPatientToQueue(gum_surgery_treatment, patients_[2]);
 
     EXPECT_THAT(sut_.treatmentsHavingQueue(),
                 UnorderedElementsAre(filling_treatment, tooth_extraction_treatment, gum_surgery_treatment));
@@ -398,13 +373,11 @@ TEST_F(DoctorsHavingQueueShould, ReturnEmptyDoctorListAfterReserveQueueInitialis
 
 TEST_F(DoctorsHavingQueueShould, ReturnListOfAllDoctorsWithAtLeastOnePatientAwaiting)
 {
-    // first doctor queue
-    sut_.addAwaitingPatient(doctors_[0], patients_[3]);
-    sut_.addAwaitingPatient(doctors_[0], patients_[2]);
-    sut_.addAwaitingPatient(doctors_[0], patients_[1]);
-    sut_.addAwaitingPatient(doctors_[0], patients_[0]);
-    // second doctor queue
-    sut_.addAwaitingPatient(doctors_[1], patients_[2]);
+    sut_.addPatientToQueue(doctors_[0], patients_[3]);
+    sut_.addPatientToQueue(doctors_[0], patients_[2]);
+    sut_.addPatientToQueue(doctors_[0], patients_[1]);
+    sut_.addPatientToQueue(doctors_[0], patients_[0]);
+    sut_.addPatientToQueue(doctors_[1], patients_[2]);
 
     EXPECT_THAT(sut_.doctorsHavingQueue(), UnorderedElementsAre(doctors_[0], doctors_[1]));
 }

--- a/src/tests/ut/reserve_queue/reserve_queue_test.hpp
+++ b/src/tests/ut/reserve_queue/reserve_queue_test.hpp
@@ -7,13 +7,24 @@
 
 class ReserveQueueFixture : public ::testing::Test
 {
-
   protected:
     ReserveQueue sut_;
     std::vector<std::shared_ptr<Patient>> patients_;
     std::vector<std::shared_ptr<Doctor>> doctors_;
     constexpr static size_t predicted_number_of_patients{4};
     constexpr static size_t predicted_number_of_dotors{3};
+
+    void expectTreatmentsHavingQueueEmpty() const
+    {
+        const auto treatments_awaiting_after_removal_attempts = sut_.treatmentsHavingQueue();
+        EXPECT_TRUE(treatments_awaiting_after_removal_attempts.empty());
+    }
+
+    void expectDoctorsHavingQueueEmpty() const
+    {
+        const auto doctors_with_patients_awaiting_appointments_after_removal_attempts = sut_.doctorsHavingQueue();
+        EXPECT_TRUE(doctors_with_patients_awaiting_appointments_after_removal_attempts.empty());
+    }
 
   public:
     void SetUp() override
@@ -30,7 +41,7 @@ class ReserveQueueFixture : public ::testing::Test
         patients_ = Clinic::getPatients();
         doctors_ = Clinic::getDoctors();
 
-        checkIfAssumedPatientsAndDoctorsPresent();
+        assertPatientsAndDoctorsPresent();
     }
 
     void TearDown() override
@@ -38,7 +49,7 @@ class ReserveQueueFixture : public ::testing::Test
         cleanupClinic();
     }
 
-    void checkIfAssumedPatientsAndDoctorsPresent()
+    void assertPatientsAndDoctorsPresent()
     {
         ASSERT_EQ(doctors_.size(), predicted_number_of_dotors);
         ASSERT_EQ(patients_.size(), predicted_number_of_patients);

--- a/src/tests/ut/reserve_queue/reserve_queue_test.hpp
+++ b/src/tests/ut/reserve_queue/reserve_queue_test.hpp
@@ -1,0 +1,46 @@
+#pragma once
+
+#include "clinic_facade.hpp"
+#include "reserve_queue.hpp"
+#include "test_utils.hpp"
+#include "gtest/gtest.h"
+
+class ReserveQueueFixture : public ::testing::Test
+{
+
+  protected:
+    ReserveQueue sut_;
+    std::vector<std::shared_ptr<Patient>> patients_;
+    std::vector<std::shared_ptr<Doctor>> doctors_;
+    constexpr static size_t predicted_number_of_patients{4};
+    constexpr static size_t predicted_number_of_dotors{3};
+
+  public:
+    void SetUp() override
+    {
+        Doctor::createDoctor("Tomasz", "Zutek", "98041000079");
+        Doctor::createDoctor("Joanna", "Iksińska", "98041000079");
+        Doctor::createDoctor("Zuzanna", "Misiowa", "28032507069");
+
+        Patient::createPatient("Jakub", "Wąsaty", "98041000079", {Allergen::SomeAllergen});
+        Patient::createPatient("Jan", "Nowak", "39032302226", {Allergen::DifferentAllergen});
+        Patient::createPatient("Maria", "Maria", "33121907675", {Allergen::DifferentAllergen});
+        Patient::createPatient("Piotr", "Lewandowski", "54091904398");
+
+        patients_ = Clinic::getPatients();
+        doctors_ = Clinic::getDoctors();
+
+        checkIfAssumedPatientsAndDoctorsPresent();
+    }
+
+    void TearDown() override
+    {
+        cleanupClinic();
+    }
+
+    void checkIfAssumedPatientsAndDoctorsPresent()
+    {
+        ASSERT_EQ(doctors_.size(), predicted_number_of_dotors);
+        ASSERT_EQ(patients_.size(), predicted_number_of_patients);
+    }
+};

--- a/src/tests/ut/reserve_queue/reserve_queue_test.hpp
+++ b/src/tests/ut/reserve_queue/reserve_queue_test.hpp
@@ -14,15 +14,15 @@ class ReserveQueueFixture : public ::testing::Test
     constexpr static size_t predicted_number_of_patients{4};
     constexpr static size_t predicted_number_of_dotors{3};
 
-    void expectTreatmentsHavingQueueEmpty() const
+    void expectTreatmentQueuesEmpty() const
     {
-        const auto treatments_awaiting_after_removal_attempts = sut_.treatmentsHavingQueue();
+        const auto treatments_awaiting_after_removal_attempts = sut_.getTreatmentQueues();
         EXPECT_TRUE(treatments_awaiting_after_removal_attempts.empty());
     }
 
-    void expectDoctorsHavingQueueEmpty() const
+    void expectDoctorQueuesEmpty() const
     {
-        const auto doctors_with_patients_awaiting_appointments_after_removal_attempts = sut_.doctorsHavingQueue();
+        const auto doctors_with_patients_awaiting_appointments_after_removal_attempts = sut_.getDoctorQueues();
         EXPECT_TRUE(doctors_with_patients_awaiting_appointments_after_removal_attempts.empty());
     }
 

--- a/src/tests/ut/visit/visit_test.hpp
+++ b/src/tests/ut/visit/visit_test.hpp
@@ -2,6 +2,7 @@
 
 #include "clinic_facade.hpp"
 #include "doctor.hpp"
+#include "test_utils.hpp"
 #include "visit.hpp"
 #include "gtest/gtest.h"
 
@@ -17,23 +18,6 @@ class VisitTestFixture : public ::testing::Test
 
     void TearDown() override
     {
-        for (const auto& visit : Clinic::getVisits())
-        {
-            Clinic::removeVisit(visit);
-        }
-
-        for (const auto& doctor : Clinic::getDoctors())
-        {
-            Clinic::removeDoctor(doctor);
-        }
-        for (const auto& receptionist : Clinic::getReceptionists())
-        {
-            Clinic::removeReceptionist(receptionist);
-        }
-
-        for (const auto& patient : Clinic::getPatients())
-        {
-            Clinic::removePatient(patient);
-        }
+        cleanupClinic();
     }
 };


### PR DESCRIPTION
Introduced ReserveQueue class.

Most of function names have new proposal for names (picked carefully IMHO)  differ when compared to current documentation.
If names are accepted and PR is merged - I will update Docs accordingly.

After some thought I decided that makeAppointment() from docs makes no sense in this class.
It would be Single Responsibility rule violation - it is not up to ResevrveQueue to make new Visists. 
Other classes should be/are responsible for new visit creations.

Some minor corrections to CMakeLists.txt files introduced with minor fixes of fixed include paths.

Introduced test utils with one function so far  - cleanupClinic().