### PR TITLE
App module introduced and qt with docker integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ ui_*.h
 *.jsc
 Makefile*
 *build-*
+build*
 *.qm
 *.prl
 

--- a/backend_and_app_build.sh
+++ b/backend_and_app_build.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# This script is used to clean the build directory then build the backend and application
+rm -rf build_backend
+
+rm -rf build_app
+
+set -e
+
+mkdir build_backend && cd build_backend
+
+cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTS=OFF ../modules/backend/
+
+cmake --build . --parallel --clean-first -- -j2
+
+mkdir ../build_app && cd ../build_app
+
+cmake ../modules/app/
+
+cmake --build . --parallel --clean-first -- -j2

--- a/create_container.sh
+++ b/create_container.sh
@@ -1,0 +1,8 @@
+
+# Run ONCE to create container
+
+#!/bin/bash
+docker build -t desktop-business-app .
+
+# Run the container in the background (detached mode)
+docker run -d --name desktop-business-app --net=host -e DISPLAY=$DISPLAY -v $(pwd):/application -w /application desktop-business-app tail -f /dev/null

--- a/dependencies.sh
+++ b/dependencies.sh
@@ -12,4 +12,5 @@ apt install -y \
     libgoogle-glog-dev \
     protobuf-compiler libprotobuf-dev \
     git \
-    valgrind
+    valgrind \
+    qml6-module-*

--- a/dependencies.sh
+++ b/dependencies.sh
@@ -6,6 +6,7 @@ apt install -y \
     libgtest-dev libgmock-dev \
     cmake make g++ \
     qt6-base-dev \
+    qt6-declarative-dev \
     libgl1-mesa-dev \
     libssl-dev \
     nlohmann-json3-dev \

--- a/modules/app/CMakeLists.txt
+++ b/modules/app/CMakeLists.txt
@@ -1,0 +1,28 @@
+cmake_minimum_required(VERSION 3.23)
+project(desktop-business-app)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED on)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR}/../../bin)
+link_directories(${PROJECT_SOURCE_DIR}/../../libs/)
+
+find_package(Qt6 REQUIRED COMPONENTS Quick Gui)
+
+qt_standard_project_setup()
+
+qt_add_executable(${PROJECT_NAME} main.cpp)
+
+target_link_libraries(${PROJECT_NAME} PRIVATE Qt6::Gui
+                                              Qt6::Quick
+                                              libclinic-lib.a
+                                              libcommon-lib.a
+                                              libpatients-lib.a
+                                              libprotobuff.a
+                                              libserializer-lib.a
+                                              libvisits-lib.a
+                                              libwarehouse-lib.a)
+
+qt_add_qml_module(${PROJECT_NAME}
+                    URI desktop-business-app
+                    VERSION 1.0
+                    QML_FILES main.qml)

--- a/modules/app/main.cpp
+++ b/modules/app/main.cpp
@@ -1,0 +1,13 @@
+#include <QGuiApplication>
+#include <QQmlApplicationEngine>
+
+int main(int argc, char* argv[])
+{
+    QGuiApplication app(argc, argv);
+
+    QQmlApplicationEngine engine;
+    const QUrl url(u"qrc:/desktop-business-app/main.qml"_qs);
+    engine.load(url);
+
+    return app.exec();
+}

--- a/modules/app/main.qml
+++ b/modules/app/main.qml
@@ -1,0 +1,10 @@
+import QtQuick
+
+Window {
+    id: root
+    visible: true
+    Text {
+        text: "Hello, world!"
+        anchors.centerIn: parent
+    }
+}

--- a/run_container.sh
+++ b/run_container.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-# Build the Docker image
-docker build -t desktop-business-app .
-
-# Run the container in the background (detached mode)
-docker run -d --name desktop-business-app -v $(pwd):/application -w /application desktop-business-app tail -f /dev/null
+docker start desktop-business-app
+xhost +local:docker
+docker exec -it desktop-business-app bash

--- a/run_container.sh
+++ b/run_container.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 
-docker start desktop-business-app
 xhost +local:docker
 docker exec -it desktop-business-app bash


### PR DESCRIPTION
1. App module added. Backend and app modules are separate CMake projects and has separate CMakeLists.txt files.
![obraz](https://github.com/user-attachments/assets/1ef69e60-5b95-4fb3-8659-761706463046)
2. To build window app use new script backend_and_app_build.sh
3. To create docker image and container use script create_container.sh and to enter container use script run_container.sh
4. QT now works in container