### PR TITLE
Move to nobel lts, update dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:mantic AS build
+FROM ubuntu:noble AS build
 ENV PROJECT_NAME=desktop-business-app
 WORKDIR /application
 

--- a/clang-fmt-all.sh
+++ b/clang-fmt-all.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-# Find all .cpp, .h, and .hpp files and format them using clang-format
-find ./ -name '*.cpp' -or -name '*.hpp' | xargs clang-format --verbose -style=file -i

--- a/dependencies.sh
+++ b/dependencies.sh
@@ -14,4 +14,5 @@ apt install -y \
     protobuf-compiler libprotobuf-dev \
     git \
     valgrind \
+    clang-format \
     qml6-module-*


### PR DESCRIPTION
Updating docker due to error on mantic 'no longer Release file` 
E: The repository 'http://archive.ubuntu.com/ubuntu mantic Release' no longer has a Release file.